### PR TITLE
feat(beerus_core): fetch last proven block on the fly

### DIFF
--- a/beerus_cli/tests/cli.rs
+++ b/beerus_cli/tests/cli.rs
@@ -191,7 +191,7 @@ mod test {
         starknet_lightclient
             .expect_get_storage_at()
             .times(1)
-            .return_once(move |_address, _key| Ok(expected_result));
+            .return_once(move |_address, _key, _block_nb| Ok(expected_result));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -232,7 +232,9 @@ mod test {
         starknet_lightclient
             .expect_get_storage_at()
             .times(1)
-            .return_once(move |_address, _key| Err(eyre::eyre!("starknet_lightclient_error")));
+            .return_once(move |_address, _key, _block_nb| {
+                Err(eyre::eyre!("starknet_lightclient_error"))
+            });
 
         let beerus = BeerusLightClient::new(
             config,
@@ -280,7 +282,7 @@ mod test {
         starknet_lightclient
             .expect_call()
             .times(1)
-            .return_once(move |_req| Ok(expected_result));
+            .return_once(move |_req, _block_nb| Ok(expected_result));
 
         let beerus = BeerusLightClient::new(
             config,

--- a/beerus_cli/tests/cli.rs
+++ b/beerus_cli/tests/cli.rs
@@ -183,7 +183,7 @@ mod test {
     #[tokio::test]
     async fn given_normal_conditions_when_query_storage_then_ok() {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
         let expected_result = FieldElement::from_dec_str("298305742194").unwrap();
@@ -192,6 +192,10 @@ mod test {
             .expect_get_storage_at()
             .times(1)
             .return_once(move |_address, _key, _block_nb| Ok(expected_result));
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -225,7 +229,7 @@ mod test {
     async fn given_starknet_lightclient_returns_error_when_query_storage_then_error_is_propagated()
     {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
         // Set the expected return value for the StarkNet light client mock.
@@ -235,7 +239,10 @@ mod test {
             .return_once(move |_address, _key, _block_nb| {
                 Err(eyre::eyre!("starknet_lightclient_error"))
             });
-
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
         let beerus = BeerusLightClient::new(
             config,
             Box::new(ethereum_lightclient),
@@ -270,7 +277,7 @@ mod test {
     #[tokio::test]
     async fn given_normal_conditions_when_query_contract_then_ok() {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
         let expected_result = vec![
@@ -283,6 +290,11 @@ mod test {
             .expect_call()
             .times(1)
             .return_once(move |_req, _block_nb| Ok(expected_result));
+
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         let beerus = BeerusLightClient::new(
             config,

--- a/beerus_core/src/lightclient/beerus.rs
+++ b/beerus_core/src/lightclient/beerus.rs
@@ -101,7 +101,6 @@ impl BeerusLightClient {
         let starknet_core_contract_address = &self.config.starknet_core_contract_address;
 
         let data = vec![53, 190, 250, 93];
-        println!("data: {:?}", data);
 
         // Build the call options.
         let call_opts = CallOpts {

--- a/beerus_core/src/lightclient/starknet/mod.rs
+++ b/beerus_core/src/lightclient/starknet/mod.rs
@@ -12,11 +12,12 @@ use url::Url;
 #[async_trait]
 pub trait StarkNetLightClient: Send + Sync {
     async fn start(&self) -> Result<()>;
-    async fn call(&self, opts: FunctionCall) -> Result<Vec<FieldElement>>;
+    async fn call(&self, opts: FunctionCall, block_number: u64) -> Result<Vec<FieldElement>>;
     async fn get_storage_at(
         &self,
         address: FieldElement,
         key: FieldElement,
+        block_number: u64,
     ) -> Result<FieldElement>;
 }
 
@@ -55,6 +56,7 @@ impl StarkNetLightClient for StarkNetLightClientImpl {
         &self,
         address: FieldElement,
         key: FieldElement,
+        _block_number: u64,
     ) -> Result<FieldElement> {
         self.client
             .get_storage_at(
@@ -80,7 +82,7 @@ impl StarkNetLightClient for StarkNetLightClientImpl {
     ///
     /// `Ok(Vec<FieldElement>)` if the operation was successful.
     /// `Err(eyre::Report)` if the operation failed.
-    async fn call(&self, request: FunctionCall) -> Result<Vec<FieldElement>> {
+    async fn call(&self, request: FunctionCall, _block_number: u64) -> Result<Vec<FieldElement>> {
         self.client
             .call(
                 request,

--- a/beerus_core/tests/beerus.rs
+++ b/beerus_core/tests/beerus.rs
@@ -284,7 +284,7 @@ mod tests {
     #[tokio::test]
     async fn given_normal_conditions_when_starknet_call_should_work() {
         // Mock config, ethereum light client and starknet light client.
-        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+        let (config, mut ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
 
         let expected_result = vec![
             FieldElement::from_hex_be("0x4e28f97185e801").unwrap(),
@@ -298,7 +298,10 @@ mod tests {
             .expect_call()
             .times(1)
             .return_once(move |_req, _block_nb| Ok(expected_result));
-
+        ethereum_lightclient_mock
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
         // Create a new Beerus light client.
         let beerus = BeerusLightClient::new(
             config,
@@ -332,7 +335,7 @@ mod tests {
     async fn given_starknet_light_client_returns_error_when_starknet_call_should_fail_with_same_error(
     ) {
         // Mock config, ethereum light client and starknet light client.
-        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+        let (config, mut ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
 
         // Set the expected return value for the Starknet light client mock.
         let expected_error = "Wrong url";
@@ -340,7 +343,10 @@ mod tests {
             .expect_call()
             .times(1)
             .return_once(move |_req, _block_nb| Err(eyre!(expected_error)));
-
+        ethereum_lightclient_mock
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
         // Create a new Beerus light client.
         let beerus = BeerusLightClient::new(
             config,
@@ -372,14 +378,17 @@ mod tests {
     #[tokio::test]
     async fn given_normal_conditions_when_starknet_get_storage_at_should_work() {
         // Mock config, ethereum light client and starknet light client.
-        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+        let (config, mut ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
         let expected_result = FieldElement::from_hex_be("298305742194").unwrap();
         // Set the expected return value for the StarkNet light client mock.
         starknet_lightclient_mock
             .expect_get_storage_at()
             .times(1)
             .return_once(move |_address, _key, _block_nb| Ok(expected_result));
-
+        ethereum_lightclient_mock
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
         // Create a new Beerus light client.
         let beerus = BeerusLightClient::new(
             config,
@@ -403,7 +412,7 @@ mod tests {
     async fn given_starknet_lightclient_returns_error_when_starknet_get_storage_at_should_fail_with_same_error(
     ) {
         // Mock config, ethereum light client and starknet light client.
-        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+        let (config, mut ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
 
         // Set the expected return value for the Starknet light client mock.
         let expected_error = "Wrong url";
@@ -411,6 +420,10 @@ mod tests {
             .expect_get_storage_at()
             .times(1)
             .return_once(move |_address, _key, _block_nb| Err(eyre!(expected_error)));
+        ethereum_lightclient_mock
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         // Create a new Beerus light client.
         let beerus = BeerusLightClient::new(

--- a/beerus_rest_api/tests/api.rs
+++ b/beerus_rest_api/tests/api.rs
@@ -186,7 +186,7 @@ mod test {
         starknet_lightclient
             .expect_get_storage_at()
             .times(1)
-            .return_once(move |_address, _key| Ok(expected_result));
+            .return_once(move |_address, _key, _block_nb| Ok(expected_result));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -225,7 +225,7 @@ mod test {
         starknet_lightclient
             .expect_get_storage_at()
             .times(1)
-            .return_once(move |_address, _key| {
+            .return_once(move |_address, _key, _block_nb| {
                 Err(eyre::eyre!("cannot query starknet get storage at"))
             });
 
@@ -268,7 +268,7 @@ mod test {
         starknet_lightclient
             .expect_call()
             .times(1)
-            .return_once(move |_req| Ok(expected_result));
+            .return_once(move |_req, _block_nb| Ok(expected_result));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -307,7 +307,7 @@ mod test {
         starknet_lightclient
             .expect_call()
             .times(1)
-            .return_once(move |_req| Err(eyre::eyre!("cannot query starknet call")));
+            .return_once(move |_req, _block_nb| Err(eyre::eyre!("cannot query starknet call")));
 
         let beerus = BeerusLightClient::new(
             config,

--- a/beerus_rest_api/tests/api.rs
+++ b/beerus_rest_api/tests/api.rs
@@ -178,7 +178,7 @@ mod test {
     #[tokio::test]
     async fn given_normal_conditions_when_query_starknet_get_storage_at_then_ok() {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
         let expected_result = FieldElement::from_hex_be("298305742194").unwrap();
@@ -187,6 +187,10 @@ mod test {
             .expect_get_storage_at()
             .times(1)
             .return_once(move |_address, _key, _block_nb| Ok(expected_result));
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -217,7 +221,7 @@ mod test {
     async fn given_starknet_ligthclient_returns_error_when_query_starknet_get_storage_at_then_error_is_propagated(
     ) {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
 
@@ -228,6 +232,10 @@ mod test {
             .return_once(move |_address, _key, _block_nb| {
                 Err(eyre::eyre!("cannot query starknet get storage at"))
             });
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -257,7 +265,7 @@ mod test {
     #[tokio::test]
     async fn given_normal_conditions_when_query_starknet_contract_view_then_ok() {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
         let expected_result = vec![
@@ -269,6 +277,10 @@ mod test {
             .expect_call()
             .times(1)
             .return_once(move |_req, _block_nb| Ok(expected_result));
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -299,7 +311,7 @@ mod test {
     async fn given_starknet_ligthclient_returns_error_when_query_starknet_contract_view_then_error_is_propagated(
     ) {
         // Build mocks.
-        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+        let (config, mut ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
 
         // Given
 
@@ -308,6 +320,10 @@ mod test {
             .expect_call()
             .times(1)
             .return_once(move |_req, _block_nb| Err(eyre::eyre!("cannot query starknet call")));
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_req, _block_nb| Ok(vec![2]));
 
         let beerus = BeerusLightClient::new(
             config,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [x] Testing
- [ ] Other (please describe):

# What is the current behavior?

The StarkNet block number is hardcoded
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Fixes #34 

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Beerus fetches the last proven block on the fly through Helios


# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
