### PR TITLE
Ethereum RPC `chain_id` query + CLI + API  + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-# Visual Studio Code
+# IDEs
 .vscode/
+.idea/
 
 # Environment files
 .env

--- a/beerus_cli/src/ethereum/mod.rs
+++ b/beerus_cli/src/ethereum/mod.rs
@@ -64,3 +64,13 @@ pub async fn query_block_number(beerus: BeerusLightClient) -> Result<CommandResp
     let block_number = beerus.ethereum_lightclient.get_block_number().await?;
     Ok(CommandResponse::EthereumQueryBlockNumber(block_number))
 }
+
+/// Query the chain id of the Ethereum network.
+/// # Arguments
+/// * `beerus` - The Beerus light client.
+/// # Returns
+/// * `Result<CommandResponse>` - The chain id of the Ethereum network.
+pub async fn query_chain_id(beerus: BeerusLightClient) -> Result<CommandResponse> {
+    let chain_id = beerus.ethereum_lightclient.chain_id().await;
+    Ok(CommandResponse::EthereumQueryChainId(chain_id))
+}

--- a/beerus_cli/src/model.rs
+++ b/beerus_cli/src/model.rs
@@ -50,6 +50,7 @@ pub enum EthereumSubCommands {
     },
 
     QueryBlockNumber {},
+    QueryChainId {},
 }
 
 /// StarkNet related commands.
@@ -97,6 +98,7 @@ pub enum CommandResponse {
     EthereumQueryBalance(String),
     EthereumQueryNonce(u64),
     EthereumQueryBlockNumber(u64),
+    EthereumQueryChainId(u64),
     StarkNetQueryStateRoot(U256),
     StarkNetQueryContract(Vec<FieldElement>),
     StarkNetQueryGetStorageAt(FieldElement),
@@ -120,6 +122,9 @@ impl Display for CommandResponse {
             CommandResponse::EthereumQueryBlockNumber(block_number) => {
                 write!(f, "{block_number}")
             }
+            // Print the chain id.
+            // Result looks like: 1
+            CommandResponse::EthereumQueryChainId(chain_id) => write!(f, "{chain_id}"),
             // Print the state root.
             // Result looks like: 2343271987571512511202187232154229702738820280823720849834887135668366687374
             CommandResponse::StarkNetQueryStateRoot(state_root) => write!(f, "{state_root}"),

--- a/beerus_cli/src/runner.rs
+++ b/beerus_cli/src/runner.rs
@@ -30,6 +30,7 @@ pub async fn run(beerus: BeerusLightClient, cli: Cli) -> Result<CommandResponse>
                 ethereum::query_nonce(beerus, address.to_string()).await
             }
             EthereumSubCommands::QueryBlockNumber {} => ethereum::query_block_number(beerus).await,
+            EthereumSubCommands::QueryChainId {} => ethereum::query_chain_id(beerus).await,
         },
         // StarkNet commands.
         Commands::StarkNet(starknet_commands) => match &starknet_commands.command {

--- a/beerus_cli/tests/cli.rs
+++ b/beerus_cli/tests/cli.rs
@@ -243,6 +243,40 @@ mod test {
         }
     }
 
+    /// Test the `query_chain_id` CLI command.
+    /// Given normal conditions, when query chain_id, then ok.
+    /// Success case.
+    #[tokio::test]
+    async fn given_normal_conditions_when_query_chain_id_then_ok() {
+        // Build mocks.
+        let (config, mut ethereum_lightclient, starknet_lightclient) = config_and_mocks();
+
+        // Given
+        // Mock dependencies.
+        ethereum_lightclient
+            .expect_chain_id()
+            .return_once(move || 1);
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+
+        // Mock the command line arguments.
+        let cli = Cli {
+            config: None,
+            command: Commands::Ethereum(EthereumCommands {
+                command: EthereumSubCommands::QueryChainId {},
+            }),
+        };
+        // When
+        let result = runner::run(beerus, cli).await.unwrap();
+
+        // Then
+        assert_eq!("1", result.to_string());
+    }
+
     /// Test the `query_state_root` CLI command.
     /// Given normal conditions, when query state root, then ok.
     #[tokio::test]

--- a/beerus_cli/tests/model.rs
+++ b/beerus_cli/tests/model.rs
@@ -9,6 +9,12 @@ mod tests {
     }
 
     #[test]
+    fn test_display_ethereum_query_chain_id() {
+        let response = CommandResponse::EthereumQueryChainId(1);
+        assert_eq!(response.to_string(), "1");
+    }
+
+    #[test]
     fn test_display_starknet_query_state_root() {
         let response = CommandResponse::StarkNetQueryStateRoot(1.into());
         assert_eq!(response.to_string(), "1");

--- a/beerus_core/src/lightclient/ethereum/helios_lightclient.rs
+++ b/beerus_core/src/lightclient/ethereum/helios_lightclient.rs
@@ -48,6 +48,10 @@ impl EthereumLightClient for HeliosLightClient {
     async fn get_block_number(&self) -> eyre::Result<u64> {
         self.helios_light_client.get_block_number().await
     }
+
+    async fn chain_id(&self) -> u64 {
+        self.helios_light_client.chain_id().await
+    }
 }
 
 /// HeliosLightClient non-trait functions.

--- a/beerus_core/src/lightclient/ethereum/mod.rs
+++ b/beerus_core/src/lightclient/ethereum/mod.rs
@@ -69,4 +69,12 @@ pub trait EthereumLightClient: Send + Sync {
     /// # TODO
     /// Add examples.
     async fn get_block_number(&self) -> Result<u64>;
+
+    /// Get the chain ID.
+    /// This function should be called after `start`.
+    /// # Returns
+    /// The chain ID.
+    /// # Errors
+    /// Cannot fail.
+    async fn chain_id(&self) -> u64;
 }

--- a/beerus_core/tests/beerus.rs
+++ b/beerus_core/tests/beerus.rs
@@ -219,6 +219,36 @@ mod tests {
         assert_eq!(result.unwrap(), expected_block_number);
     }
 
+    /// Test the `chain_id` method when everything is fine.
+    /// This test mocks external dependencies.
+    /// It does not test the `chain_id` method of the external dependencies.
+    /// It tests the `chain_id` method of the Beerus light client.
+    #[tokio::test]
+    async fn given_normal_conditions_when_call_chain_id_then_should_return_ok() {
+        // Given
+        // Mock config, ethereum light client and starknet light client.
+        let (config, mut ethereum_lightclient_mock, starknet_lightclient_mock) = mock_clients();
+
+        // Mock the `chain_id` method of the Ethereum light client.
+        let expected_chain_id = 1;
+        ethereum_lightclient_mock
+            .expect_chain_id()
+            .return_once(move || expected_chain_id);
+
+        // When
+        let beerus = BeerusLightClient::new(
+            config.clone(),
+            Box::new(ethereum_lightclient_mock),
+            Box::new(starknet_lightclient_mock),
+        );
+
+        let result = beerus.ethereum_lightclient.chain_id().await;
+
+        // Then
+        // Assert that the chain id returned by the `chain_id` method of the Beerus light client is the expected chain id.
+        assert_eq!(result, expected_chain_id);
+    }
+
     /// Test the `start` method when the StarkNet light client returns an error.
     /// This test mocks external dependencies.
     /// It does not test the `start` method of the external dependencies.

--- a/beerus_rest_api/src/api/ethereum/endpoints.rs
+++ b/beerus_rest_api/src/api/ethereum/endpoints.rs
@@ -1,5 +1,5 @@
 use crate::api::ethereum::resp::{
-    QueryBalanceResponse, QueryBlockNumberResponse, QueryNonceResponse,
+    QueryBalanceResponse, QueryBlockNumberResponse, QueryChainIdResponse, QueryNonceResponse,
 };
 use crate::api::ApiResponse;
 
@@ -36,6 +36,14 @@ pub async fn query_block_number(
     beerus: &State<BeerusLightClient>,
 ) -> ApiResponse<QueryBlockNumberResponse> {
     ApiResponse::from_result(query_block_number_inner(beerus).await)
+}
+
+#[openapi]
+#[get("/ethereum/chain_id")]
+pub async fn query_chain_id(
+    beerus: &State<BeerusLightClient>,
+) -> ApiResponse<QueryChainIdResponse> {
+    ApiResponse::from_result(query_chain_id_inner(beerus).await)
 }
 
 /// Query the balance of an Ethereum address.
@@ -108,4 +116,18 @@ pub async fn query_block_number_inner(
     debug!("Querying block number");
     let block_number = beerus.ethereum_lightclient.get_block_number().await?;
     Ok(QueryBlockNumberResponse { block_number })
+}
+
+/// Query the chain ID of the Ethereum chain.
+/// # Returns
+/// `chain_id` - The chain ID.
+/// # Errors
+/// Cannot fail.
+/// # Examples
+pub async fn query_chain_id_inner(
+    beerus: &State<BeerusLightClient>,
+) -> Result<QueryChainIdResponse> {
+    debug!("Querying chain ID");
+    let chain_id = beerus.ethereum_lightclient.chain_id().await;
+    Ok(QueryChainIdResponse { chain_id })
 }

--- a/beerus_rest_api/src/api/ethereum/resp/mod.rs
+++ b/beerus_rest_api/src/api/ethereum/resp/mod.rs
@@ -21,3 +21,9 @@ pub struct QueryNonceResponse {
 pub struct QueryBlockNumberResponse {
     pub block_number: u64,
 }
+
+#[derive(Serialize, JsonSchema)]
+#[serde(crate = "rocket::serde")]
+pub struct QueryChainIdResponse {
+    pub chain_id: u64,
+}

--- a/beerus_rest_api/src/lib.rs
+++ b/beerus_rest_api/src/lib.rs
@@ -17,6 +17,7 @@ pub async fn build_rocket_server(beerus: BeerusLightClient) -> Rocket<Build> {
             ethereum::endpoints::query_balance,
             ethereum::endpoints::query_nonce,
             ethereum::endpoints::query_block_number,
+            ethereum::endpoints::query_chain_id,
             starknet::endpoints::query_starknet_state_root,
             starknet::endpoints::query_starknet_contract_view,
             starknet::endpoints::query_starknet_get_storage_at,

--- a/beerus_rest_api/tests/api.rs
+++ b/beerus_rest_api/tests/api.rs
@@ -250,6 +250,39 @@ mod test {
         );
     }
 
+    /// Test the `chain_id` endpoint.
+    /// `/ethereum/chain_id`
+    /// Given normal conditions, when query chain id, then ok.
+    #[tokio::test]
+    async fn given_normal_conditions_when_query_chain_id_then_ok() {
+        // Build mocks.
+        let (config, mut ethereum_lightclient, starknet_lightclient) = config_and_mocks();
+
+        // Given
+        // Mock dependencies.
+        ethereum_lightclient
+            .expect_chain_id()
+            .return_once(move || 1);
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+
+        // Build the Rocket instance.
+        let client = Client::tracked(build_rocket_server(beerus).await)
+            .await
+            .expect("valid rocket instance");
+
+        // When
+        let response = client.get(uri!("/ethereum/chain_id")).dispatch().await;
+
+        // Then
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.into_string().await.unwrap(), "{\"chain_id\":1}");
+    }
+
     /// Test the `query_starknet_state_root` endpoint.
     /// `/starknet/state/root`
     /// Given normal conditions, when query starknet state root, then ok.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Implemented the Ethereum RPC call `chain_id` + CLI + API + tests.
Note : the helios lightclient call `chain_id` returns a `u64` and cannot fail.
# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #78 

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
