### PR TITLE
dev: reorder cli arg parsing

### DIFF
--- a/beerus_cli/src/main.rs
+++ b/beerus_cli/src/main.rs
@@ -13,6 +13,8 @@ use eyre::Result;
 async fn main() -> Result<()> {
     // Initialize the logger.
     env_logger::init();
+    // Parse the CLI arguments.
+    let cli = Cli::parse();
     // Read the config from the environment.
     let config = Config::new_from_env()?;
     // Create a new Ethereum light client.
@@ -27,8 +29,6 @@ async fn main() -> Result<()> {
     );
     // Start the Beerus light client.
     beerus.start().await?;
-    // Parse the CLI arguments.
-    let cli = Cli::parse();
     // Run the CLI command.
     let command_response = runner::run(beerus, cli).await?;
     // Print the command response.

--- a/beerusup
+++ b/beerusup
@@ -126,10 +126,7 @@ install_beerus_manually() {
     mv ./target/release/beerus_cli $PROJECT_BIN
     mv ./target/release/beerus_rest_api $PROJECT_BIN
 
-    # TODO: 
-    # after issue 82 is resolved get version from usage
-    # BEERUS_VER=$(beerus-cli --version)
-    BEERUS_VER=$(git rev-parse HEAD)
+    BEERUS_VER=$(beerus_cli --version | awk '{print $2}')
 
     cd $WRK_DIR
     rm -rf $PROJECT_TMP/beerus
@@ -154,8 +151,8 @@ if [ "$1" = "dev" ] || [ $? -ne 0 ]; then
     install_beerus_manually
 else
     # Pull latest release if there is a new version
-    CURRENT_VER=$(beerus_cli --version)
-    if [ "$LATEST_TAG" = "$CURRENT_VER" ]; then
+    CURRENT_VER=$(beerus_cli --version | awk '{print $2}')
+    if [ "$LATEST_TAG" = "v$CURRENT_VER" ]; then
         echo "$NAME is currently running the latest version: $LATEST_VER"
     else
         echo "$NAME being updated to $LATEST_VER"


### PR DESCRIPTION
Reorder CLI arg parsing to come before environment variable configuration so we can expose usage flags like `--version` and `--help`.

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Error on bad config when trying to print help

Issue Number: https://github.com/keep-starknet-strange/beerus/issues/82

# What is the new behavior?
- parse flags prior to config

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

# Other information

Enables `beerusup` to use cli version instead of repo commit 
