### PR TITLE
fix: beerusup uses beerus_cli full path on install

### DIFF
--- a/beerusup
+++ b/beerusup
@@ -118,7 +118,7 @@ install_beerus_manually() {
     mv ./target/release/beerus_cli $PROJECT_BIN
     mv ./target/release/beerus_rest_api $PROJECT_BIN
 
-    BEERUS_VER=$(beerus_cli --version | awk '{print $2}')
+    BEERUS_VER=$($PROJECT_BIN/beerus_cli --version | awk '{print $2}')
 
     cd $WRK_DIR
     rm -rf $PROJECT_TMP/beerus
@@ -153,7 +153,10 @@ else
 fi
 
 echo "$NAME root installed at: $PROJECT_ROOT"
-if [ ! -z "$PROFILE" ]; then echo "\trun 'source $PROFILE' to activate path"; fi
+if [ ! -z "$PROFILE" ]; then
+    echo "Run 'source $PROFILE' to activate path or start a new terminal session to use Beerus."
+    echo "Then, run 'beerus_cli --help'."
+fi
 
 echo "\nSet config:"
 echo "\tETHEREUM_EXECUTION_RPC_URL\n\tETHEREUM_CONSENSUS_RPC_URL\n\tSTARKNET_RPC_URL"

--- a/beerusup
+++ b/beerusup
@@ -143,7 +143,7 @@ if [ "$1" = "dev" ] || [ $? -ne 0 ]; then
     install_beerus_manually
 else
     # Pull latest release if there is a new version
-    CURRENT_VER=$(beerus_cli --version | awk '{print $2}')
+    CURRENT_VER=$($PROJECT_BIN/beerus_cli --version | awk '{print $2}')
     if [ "$LATEST_TAG" = "v$CURRENT_VER" ]; then
         echo "$NAME is currently running the latest version: $LATEST_VER"
     else


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Fix #116 

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `beerusup` uses `beerus_cli` full path on install
- No error and instead version is shown

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
