### PR TITLE
feat: l1ToL2MessageNonce

### DIFF
--- a/beerus_cli/src/model.rs
+++ b/beerus_cli/src/model.rs
@@ -118,6 +118,8 @@ pub enum StarkNetSubCommands {
         #[arg(short, long, value_name = "MSG_HASH")]
         msg_hash: String,
     },
+    L1ToL2MessageNonce {},
+    /// The nonce of the L1 to L2 message bridge
     QueryChainId {},
     QueryBlockNumber {},
     QueryBlockHashAndNumber {},
@@ -140,6 +142,7 @@ pub enum CommandResponse {
     StarknetQueryBlockHashAndNumber(BlockHashAndNumber),
     StarkNetL1ToL2MessageCancellations(U256),
     StarkNetL1ToL2Messages(U256),
+    StarkNetL1ToL2MessageNonce(U256),
     StarkNetL2ToL1Messages(U256),
 }
 
@@ -204,7 +207,7 @@ impl Display for CommandResponse {
             CommandResponse::StarkNetL1ToL2MessageCancellations(timestamp) => {
                 write!(f, "{timestamp}")
             }
-            // Print the msg_fee + 1 for the message with the given 'msgHash',
+            // Print  msg_fee + 1 for the message with the given 'msgHash',
             // Result looks like: 123456
             CommandResponse::StarkNetL1ToL2Messages(fee) => {
                 write!(f, "{fee}")
@@ -213,6 +216,12 @@ impl Display for CommandResponse {
             // Result looks like: 123456
             CommandResponse::StarkNetL2ToL1Messages(fee) => {
                 write!(f, "{fee}")
+            }
+
+            // Print the current nonce of the L1 to L2 message bridge,
+            // Result looks like: 123456
+            CommandResponse::StarkNetL1ToL2MessageNonce(nonce) => {
+                write!(f, "L1 to L2 Message Nonce: {nonce}")
             }
             // Print the chain id.
             // Result looks like: `Chain id: 1`

--- a/beerus_cli/src/model.rs
+++ b/beerus_cli/src/model.rs
@@ -118,8 +118,8 @@ pub enum StarkNetSubCommands {
         #[arg(short, long, value_name = "MSG_HASH")]
         msg_hash: String,
     },
-    L1ToL2MessageNonce {},
     /// The nonce of the L1 to L2 message bridge
+    L1ToL2MessageNonce {},
     QueryChainId {},
     QueryBlockNumber {},
     QueryBlockHashAndNumber {},
@@ -217,7 +217,6 @@ impl Display for CommandResponse {
             CommandResponse::StarkNetL2ToL1Messages(fee) => {
                 write!(f, "{fee}")
             }
-
             // Print the current nonce of the L1 to L2 message bridge,
             // Result looks like: 123456
             CommandResponse::StarkNetL1ToL2MessageNonce(nonce) => {
@@ -228,7 +227,6 @@ impl Display for CommandResponse {
             CommandResponse::StarknetQueryChainId(chain_id) => {
                 write!(f, "Chain id: {chain_id}")
             }
-
             // Print the current block number.
             // Result looks like: `Block number: 123456`
             CommandResponse::StarknetQueryBlockNumber(block_number) => {

--- a/beerus_cli/src/runner.rs
+++ b/beerus_cli/src/runner.rs
@@ -80,6 +80,9 @@ pub async fn run(beerus: BeerusLightClient, cli: Cli) -> Result<CommandResponse>
             StarkNetSubCommands::L2ToL1Messages { msg_hash } => {
                 starknet::query_starknet_l2_to_l1_messages(beerus, msg_hash.to_string()).await
             }
+            StarkNetSubCommands::L1ToL2MessageNonce {} => {
+                starknet::query_starknet_l1_to_l2_message_nonce(beerus).await
+            }
             StarkNetSubCommands::QueryChainId {} => starknet::query_chain_id(beerus).await,
             StarkNetSubCommands::QueryBlockNumber {} => starknet::query_block_number(beerus).await,
             StarkNetSubCommands::QueryBlockHashAndNumber {} => {

--- a/beerus_cli/src/starknet/mod.rs
+++ b/beerus_cli/src/starknet/mod.rs
@@ -169,7 +169,7 @@ pub async fn query_starknet_l2_to_l1_messages(
 /// # Arguments
 /// * `beerus` - The Beerus light client.
 /// # Returns
-/// * `Result<()>` - The result of the query.
+/// * `Result<CommandResponse>` - The result of the query.
 /// # Errors
 /// * If the StarkNet nonce query fails.
 pub async fn query_starknet_l1_to_l2_message_nonce(

--- a/beerus_cli/src/starknet/mod.rs
+++ b/beerus_cli/src/starknet/mod.rs
@@ -165,6 +165,21 @@ pub async fn query_starknet_l2_to_l1_messages(
     ))
 }
 
+/// Query l1 to l2 message nonce
+/// # Arguments
+/// * `beerus` - The Beerus light client.
+/// # Returns
+/// * `Result<()>` - The result of the query.
+/// # Errors
+/// * If the StarkNet nonce query fails.
+pub async fn query_starknet_l1_to_l2_message_nonce(
+    beerus: BeerusLightClient,
+) -> Result<CommandResponse> {
+    Ok(CommandResponse::StarkNetL1ToL2MessageNonce(
+        beerus.starknet_l1_to_l2_message_nonce().await?,
+    ))
+}
+
 /// Query the chain id of the StarkNet network.
 /// # Arguments
 /// * `beerus` - The Beerus light client.

--- a/beerus_cli/tests/cli.rs
+++ b/beerus_cli/tests/cli.rs
@@ -1039,6 +1039,45 @@ mod test {
         }
     }
 
+    /// Test the `starknet_l1_to_l2_message_nonce` CLI command.
+    /// Given normal conditions, when query nonce, then ok.
+    /// Success case.
+    #[tokio::test]
+    async fn starknet_l1_to_l2_message_nonce_should_return_the_nonce() {
+        // Given
+        let (config, mut ethereum_lightclient, starknet_lightclient) = config_and_mocks();
+
+        // Expected block number.
+        let expected_nonce = U256::from(1234);
+        // Convert to bytes because that's what the mock returns.
+        let mut expected_nonce_bytes: Vec<u8> = vec![0; 32];
+        expected_nonce.to_big_endian(&mut expected_nonce_bytes);
+
+        // Mock the next call to the Ethereum light client (starknet_core.l1ToL2MessageNonce)
+        ethereum_lightclient
+            .expect_call()
+            .times(1)
+            .return_once(move |_call_opts, _block_tag| Ok(expected_nonce_bytes));
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+        let cli = Cli {
+            config: None,
+            command: Commands::StarkNet(StarkNetCommands {
+                command: StarkNetSubCommands::L1ToL2MessageNonce {},
+            }),
+        };
+
+        // When
+        let result = runner::run(beerus, cli).await.unwrap();
+
+        // Then
+        assert_eq!("L1 to L2 Message Nonce: 1234", result.to_string());
+    }
+
     fn config_and_mocks() -> (Config, MockEthereumLightClient, MockStarkNetLightClient) {
         let config = Config {
             ethereum_network: "mainnet".to_string(),

--- a/beerus_cli/tests/model.rs
+++ b/beerus_cli/tests/model.rs
@@ -61,4 +61,10 @@ mod tests {
             "Block hash: 123456, Block number: 123456"
         );
     }
+
+    #[test]
+    fn test_display_starknet_query_l1_to_l2_message_nonce() {
+        let response = CommandResponse::StarkNetL1ToL2MessageNonce(123.into());
+        assert_eq!(response.to_string(), "L1 to L2 Message Nonce: 123");
+    }
 }

--- a/beerus_core/src/lightclient/ethereum/mod.rs
+++ b/beerus_core/src/lightclient/ethereum/mod.rs
@@ -14,7 +14,7 @@ use primitive_types::U256;
 #[automock]
 #[async_trait]
 pub trait EthereumLightClient: Send + Sync {
-    /// Start and synchronise the Ethereum light client.
+    /// Start and synchronize the Ethereum light client.
     /// This function should be called before any other function.
     ///
     /// # Returns

--- a/beerus_rest_api/src/api/starknet/endpoints.rs
+++ b/beerus_rest_api/src/api/starknet/endpoints.rs
@@ -1,7 +1,8 @@
 use super::resp::{
     QueryBlockHashAndNumberResponse, QueryBlockNumberResponse, QueryChainIdResponse,
     QueryContractViewResponse, QueryGetStorageAtResponse, QueryL1ToL2MessageCancellationsResponse,
-    QueryL1ToL2MessagesResponse, QueryNonceResponse, QueryStateRootResponse,
+    QueryL1ToL2MessageNonceResponse, QueryL1ToL2MessagesResponse, QueryNonceResponse,
+    QueryStateRootResponse,
 };
 use crate::api::ApiResponse;
 
@@ -113,6 +114,15 @@ pub async fn query_l2_to_l1_messages(
     msg_hash: String,
 ) -> ApiResponse<QueryL2ToL1MessagesResponse> {
     ApiResponse::from_result(query_l2_to_l1_messages_inner(beerus, msg_hash).await)
+}
+
+/// Query l1_to_l2_message_nonce call
+#[openapi]
+#[get("/starknet/messaging/l1_to_l2_message_nonce")]
+pub async fn query_l1_to_l2_message_nonce(
+    beerus: &State<BeerusLightClient>,
+) -> ApiResponse<QueryL1ToL2MessageNonceResponse> {
+    ApiResponse::from_result(query_l1_to_l2_message_nonce_inner(beerus).await)
 }
 
 /// Query the state root of StarkNet.
@@ -356,5 +366,20 @@ pub async fn query_starknet_block_hash_and_number_inner(
     Ok(QueryBlockHashAndNumberResponse {
         block_hash: response.block_hash.to_string(),
         block_number: response.block_number.to_string(),
+    })
+}
+
+/// Query the l1 to l2 message nonce
+/// # Returns
+/// `nonce` - The nonce.
+/// # Errors
+/// Cannot fail.
+/// # Examples
+pub async fn query_l1_to_l2_message_nonce_inner(
+    beerus: &State<BeerusLightClient>,
+) -> Result<QueryL1ToL2MessageNonceResponse> {
+    debug!("Querying l1 to l2 message nonce");
+    Ok(QueryL1ToL2MessageNonceResponse {
+        result: beerus.starknet_l1_to_l2_message_nonce().await?.to_string(),
     })
 }

--- a/beerus_rest_api/src/api/starknet/resp/mod.rs
+++ b/beerus_rest_api/src/api/starknet/resp/mod.rs
@@ -44,6 +44,12 @@ pub struct QueryL2ToL1MessagesResponse {
 
 #[derive(Serialize, JsonSchema)]
 #[serde(crate = "rocket::serde")]
+pub struct QueryL1ToL2MessageNonceResponse {
+    pub result: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(crate = "rocket::serde")]
 pub struct QueryChainIdResponse {
     pub chain_id: String,
 }

--- a/beerus_rest_api/src/lib.rs
+++ b/beerus_rest_api/src/lib.rs
@@ -27,6 +27,7 @@ pub async fn build_rocket_server(beerus: BeerusLightClient) -> Rocket<Build> {
             starknet::endpoints::query_l1_to_l2_message_cancellations,
             starknet::endpoints::query_l1_to_l2_messages,
             starknet::endpoints::query_l2_to_l1_messages,
+            starknet::endpoints::query_l1_to_l2_message_nonce,
             starknet::endpoints::query_starknet_chain_id,
             starknet::endpoints::query_starknet_block_number,
             starknet::endpoints::query_starknet_block_hash_and_number,


### PR DESCRIPTION
# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Feature not implemented

Resolves #98 

# What is the new behavior?

Implemented in core, cli & api

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information

I was not sure about the key of the response JSON in the API : used `result`, should it be `nonce` ?