### PR TITLE
Add storage proof verification

### DIFF
--- a/beerus_core/src/lightclient/starknet/mod.rs
+++ b/beerus_core/src/lightclient/starknet/mod.rs
@@ -8,6 +8,8 @@ use starknet::{
 };
 use url::Url;
 
+pub mod storage_proof;
+
 #[automock]
 #[async_trait]
 pub trait StarkNetLightClient: Send + Sync {

--- a/beerus_core/src/lightclient/starknet/storage_proof.rs
+++ b/beerus_core/src/lightclient/starknet/storage_proof.rs
@@ -1,0 +1,221 @@
+use serde::de;
+use serde::{Deserialize, Deserializer};
+use starknet::core::crypto::pedersen_hash;
+use starknet::core::types::FieldElement;
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct Path {
+    #[serde(deserialize_with = "from_hex_deser")]
+    value: FieldElement,
+    len: u8,
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct Edge {
+    pub path: Path,
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub child: FieldElement,
+}
+
+/// Lightweight representation of [BinaryNode]. Only holds left and right hashes.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct Binary {
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub left: FieldElement,
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub right: FieldElement,
+}
+
+impl Edge {
+    fn hash(&self) -> FieldElement {
+        let child_hash = self.child;
+
+        // Length should be smaller than the maximum size of a stark hash.
+        let length = FieldElement::from(self.path.len);
+
+        pedersen_hash(&child_hash, &self.path.value) + length
+    }
+}
+
+impl Binary {
+    fn hash(&self) -> FieldElement {
+        pedersen_hash(&self.left, &self.right)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub enum ProofNode {
+    Binary(Binary),
+    Edge(Edge),
+}
+
+impl ProofNode {
+    fn hash(&self) -> FieldElement {
+        match self {
+            ProofNode::Binary(bin) => bin.hash(),
+            ProofNode::Edge(edge) => edge.hash(),
+        }
+    }
+}
+
+// TODO
+fn from_hex_deser<'de, D>(deserializer: D) -> Result<FieldElement, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: &str = de::Deserialize::deserialize(deserializer)?;
+    FieldElement::from_hex_be(s).map_err(de::Error::custom)
+}
+
+/// Holds the data and proofs for a specific contract.
+#[derive(Debug, Deserialize)]
+pub struct ContractData {
+    /// Required to verify the contract state hash to contract root calculation.
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub class_hash: FieldElement,
+    /// Required to verify the contract state hash to contract root calculation.
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub nonce: FieldElement,
+
+    /// Root of the Contract state tree
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub root: FieldElement,
+
+    /// This is currently just a constant = 0, however it might change in the future.
+    #[serde(deserialize_with = "from_hex_deser")]
+    pub contract_state_hash_version: FieldElement,
+
+    /// The proofs associated with the queried storage values
+    pub storage_proofs: Vec<Vec<ProofNode>>,
+}
+
+/// Holds the membership/non-membership of a contract and its associated contract contract if the contract exists.
+#[derive(Debug, Deserialize)]
+pub struct GetProofOutput {
+    /// Membership / Non-membership proof for the queried contract
+    pub contract_proof: Vec<ProofNode>,
+
+    /// Additional contract data if it exists.
+    pub contract_data: Option<ContractData>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Membership {
+    Member,
+    NonMember,
+}
+
+// TODO docs
+fn path_matches(value: FieldElement, remaining_path: &[bool]) -> bool {
+    let bits = felt_to_bits_be(value);
+    &bits[bits.len() - remaining_path.len()..] == remaining_path
+}
+
+// TODO docs
+pub fn felt_to_bits_be(value: FieldElement) -> [bool; 256] {
+    let mut bits = value.to_bits_le();
+    bits.reverse();
+    bits
+}
+
+pub struct ProofRequest<'a> {
+    root: FieldElement,
+    key: &'a [bool],
+    value: FieldElement,
+    proof: &'a [ProofNode],
+}
+
+impl<'a> ProofRequest<'a> {
+    pub fn new(
+        root: FieldElement,
+        key: &'a [bool],
+        value: FieldElement,
+        proof: &'a [ProofNode],
+    ) -> Self {
+        Self {
+            root,
+            key,
+            value,
+            proof,
+        }
+    }
+
+    pub fn verify(&self) -> Option<Membership> {
+        // Protect from ill-formed keys
+        if self.key.len() < 251 {
+            return None;
+        }
+
+        let mut expected_hash = self.root;
+        let mut remaining_path = self.key;
+
+        for proof_node in self.proof.iter() {
+            // Hash mismatch? Return None.
+            if proof_node.hash() != expected_hash {
+                return None;
+            }
+            match proof_node {
+                ProofNode::Binary(bin) => {
+                    // Direction will always correspond to the 0th index
+                    // because we're removing bits on every iteration.
+                    let direction = remaining_path[0];
+
+                    // Set the next hash to be the left or right hash,
+                    // depending on the direction
+                    expected_hash = match direction {
+                        false => bin.left,
+                        true => bin.right,
+                    };
+
+                    // Advance by a single bit
+                    remaining_path = &remaining_path[1..];
+                }
+                ProofNode::Edge(edge) => {
+                    let path_matches =
+                        path_matches(edge.path.value, &remaining_path[..edge.path.len as usize]);
+                    if !path_matches {
+                        // If paths don't match, we've found a proof of non membership because we:
+                        // 1. Correctly moved towards the target insofar as is possible, and
+                        // 2. hashing all the nodes along the path does result in the root hash, which means
+                        // 3. the target definitely does not exist in this tree
+                        return Some(Membership::NonMember);
+                    }
+
+                    // Set the next hash to the child's hash
+                    expected_hash = edge.child;
+
+                    // Advance by the whole edge path
+                    remaining_path = &remaining_path[edge.path.len as usize..];
+                }
+            }
+        }
+
+        // At this point, we should reach `value` !
+        if expected_hash == self.value {
+            Some(Membership::Member)
+        } else {
+            // Hash mismatch. Return `None`.
+            None
+        }
+    }
+}
+
+pub fn verify_full_proof(
+    contract_request: ProofRequest,
+    storage_requests: &[ProofRequest],
+) -> Option<Vec<Option<Membership>>> {
+    // Verify the contract proof
+    let contract_verified = contract_request.verify()?;
+
+    // Return None if it's invalid
+    if contract_verified == Membership::NonMember {
+        return None;
+    }
+
+    // Verify Storage Proofs
+    let mut res = vec![];
+    for request in storage_requests {
+        res.push(request.verify());
+    }
+    Some(res)
+}

--- a/beerus_core/tests/data.json
+++ b/beerus_core/tests/data.json
@@ -1,0 +1,132 @@
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "contract_proof": [
+            {
+                "Binary": {
+                    "left": "0x6088eafaf0673d5277d465330fbcc946889997526b31dc5f48c4d58491af44e",
+                    "right": "0x599b71be34606a6bdffa82f339ba7c7ccd08c34d70c6d070bbbfde896656498"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x1326b221a89888b6da85f1f9ac4d8e1b565a7eba1461e84b510669c0eed7254",
+                    "right": "0x7d3b02ec3acb848c76a9a827ea70c44922420b0ce37d4cd9104c8a9ffce2fbe"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x76efe2284ef8d83e0af857b423c241692f6886c72430e019db1aefc389ce587",
+                    "right": "0x196325ad675d923995126b1707375cee1ddef97c2236c0b0de37e4b13d66ad3"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x52b662df84a8bccd3d8763d1d209e8863aab572cda546cc7b38790affc7e0b9",
+                    "right": "0x6edde0ba2c807dc8cd875c356ddb6eb7fe518fa013f54af662dbd17950504f8"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x317cabfb30acbfb2bafa3a3944ea8385087475291e282bdf46ad95c1285c5b3",
+                    "right": "0x7a9eb298d8274edd0759feda92c9d655dd6f1c6e5adfe0114e10576bfca0bdd"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x95416cb4b476155a382af243e7f2c3d3d4c8a666f3fecf305f1f9953ac8eda",
+                    "right": "0x2c862f7dac7de47e47e3247824bf5c8dff760515742c7ea35c20c0b79cea85c"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x67a5b63ec1f4b8672b1bc6da1ae2d655788a80883349ffea0115f9c40453f0",
+                    "right": "0x234b583cdf424cf175b318a18eed355c89f69371f68cd4c7265531cc7edb3e6"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x79d8f72c5d4f8d845d43497c0d4a731fdf9f5624b8b6b7381ea49a079cc6a52",
+                    "right": "0x7d08d7b553bb2b2c2aaece8d83bddd288d43332c0b2785520ef857497d1cf7e"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x1a362b0f4c2bc3474a0d94c90db4c906dbfabbb8fd3caf9d1a0680736417abd",
+                    "right": "0x102f9b064c8a3f1addffe55ac8234b4d8a0282b2e9ce3fe40560583ca11f515"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x14c957ae6bed1a4d281d1ba18e626636306a387114b7fce116cb582e49a0c5a",
+                    "right": "0xd90d957ebb41912e87f7ab98cda0c38a34454976c2fba6543b6f48cee4c1d5"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x21ba972472bba4884990e622525d688c37bd9a57e9bc1731ed796371c76a6f6",
+                    "right": "0x72ab4534ca96619189ae6ac3b686d45831143714535fd9fef0eb4c647becefa"
+                }
+            },
+            {
+                "Binary": {
+                    "left": "0x541079ae225b9999405b90c6dfd2a97bc16ee4642cf638114a6c1729806464d",
+                    "right": "0x61e56e543bd691f32a14996f9eb35965bd7a812f8456e6a8e38a46038f419bd"
+                }
+            },
+            {
+                "Edge": {
+                    "path": {
+                        "value": "0x607157aeb54abeb64f5792145f2e8db1c83bda01a8f06e050be18cfb8153",
+                        "len": 239
+                    },
+                    "child": "0x3a9cb941f554ed0ee500c47f7c54c0eef7608e5dea9f15110f5f91f8ffc0724"
+                }
+            }
+        ],
+        "contract_data": {
+            "class_hash": "0x10455c752b86932ce552f2b0fe81a880746649b9aee7e0d842bf3f52378f9f8",
+            "nonce": "0x0",
+            "root": "0x3dea434f623bd5e269756c363fc68644f0378b1a2e090813b189bcd00890faf",
+            "contract_state_hash_version": "0x0",
+            "storage_proofs": [
+                [
+                    {
+                        "Binary": {
+                            "left": "0x35ad055a5678edc2681f611f3a5e8ef30338a0f355a1ebe92a97bfd7fb46043",
+                            "right": "0x4c8dc22a26049b128b15eaf6eb4a5c9aaf2be2f884fcf21fbce951dc7b6225d"
+                        }
+                    },
+                    {
+                        "Binary": {
+                            "left": "0x3c04edb7912de9ff5368461b42ea15cd6ad1439b1a7d2f449c685ab5ef7d1df",
+                            "right": "0x626ef0f5568f97297a74f1642dea9111e1acd5a6aab5236c45ab1a7d2e4579"
+                        }
+                    },
+                    {
+                        "Binary": {
+                            "left": "0x4f5561e6fdd3f9109a788983998ebfedcd34a27631c0a6cce3f1dd04a83daf4",
+                            "right": "0x24d9c672a494ff7532a46dc3be0e94cdd1628a6a16efb7301ca0f5bea04776f"
+                        }
+                    },
+                    {
+                        "Binary": {
+                            "left": "0x2d76491b56715dd05d4b4cea61b96c8ebddb9a1904c379da369218d3ecce81b",
+                            "right": "0x1a6069b30f974199e33650c9d218d56968cc167a2dcb0e75ddf6b2dcd983d0d"
+                        }
+                    },
+                    {
+                        "Edge": {
+                            "path": {
+                                "value": "0x22ef8244ea5435f7cc3f33de473761a1c6b5084bfccb20812dc13543a642dc",
+                                "len": 247
+                            },
+                            "child": "0x7e5"
+                        }
+                    }
+                ]
+            ]
+        }
+    },
+    "id": 2
+}

--- a/beerus_core/tests/proofs.rs
+++ b/beerus_core/tests/proofs.rs
@@ -1,0 +1,57 @@
+use beerus_core::lightclient::starknet::storage_proof::{
+    felt_to_bits_be, verify_full_proof, GetProofOutput, Membership, ProofRequest,
+};
+use serde::Deserialize;
+use starknet::core::{crypto::pedersen_hash, types::FieldElement};
+use std::fs;
+
+#[derive(Debug, Deserialize)]
+struct JsonOutput {
+    result: GetProofOutput,
+}
+
+#[test]
+fn non_membership() {
+    let path = "tests/data.json";
+    let s = fs::read_to_string(path).unwrap();
+
+    let state_root = FieldElement::from_hex_be(
+        "0x47f25798a804800b657d4e1508776e3c3c70f0d7587d125a558208f88570aa7",
+    )
+    .unwrap();
+    let j: JsonOutput = serde_json::from_str(&s).unwrap();
+    let contract_proof = j.result.contract_proof;
+    let contract_address = FieldElement::from_hex_be(
+        "0x4d4e07157aeb54abeb64f5792145f2e8db1c83bda01a8f06e050be18cfb8153",
+    )
+    .unwrap();
+    let contract_data = j.result.contract_data.unwrap();
+    let class_hash = contract_data.class_hash;
+    let contract_nonce = contract_data.nonce;
+    let contract_root = contract_data.root;
+    let version = contract_data.contract_state_hash_version;
+
+    let a = pedersen_hash(&class_hash, &contract_root);
+    let b = pedersen_hash(&a, &contract_nonce);
+    let contract_value = pedersen_hash(&b, &version);
+
+    let mut contract_key = contract_address.to_bits_le();
+    contract_key.reverse();
+    let contract_request = ProofRequest::new(
+        state_root,
+        &contract_key[contract_key.len() - 251..],
+        contract_value,
+        &contract_proof,
+    );
+    let key1 = felt_to_bits_be(FieldElement::ONE);
+    let value1 = FieldElement::TWO;
+    let req1 = ProofRequest::new(
+        contract_root,
+        &key1[key1.len() - 251..],
+        value1,
+        &contract_data.storage_proofs[0],
+    );
+    let storage_requests = [req1];
+    let memberships = verify_full_proof(contract_request, &storage_requests);
+    assert_eq!(memberships, Some(vec![Some(Membership::NonMember)]));
+}


### PR DESCRIPTION
# Pull Request type

Adds the ability to verify a storage proof (as defined [here](https://github.com/eqlabs/pathfinder/issues/714)).
Closes #62 

Please check the type of change your PR introduces:

- [x] Feature

# What is the current behavior?

Can't verify proofs

Issue Number: #62 

# What is the new behavior?

Can verify proofs

- Can verify contract proofs as well as storage proofs

# Does this introduce a breaking change?

- [x] No

# Other information

- Added a `data.json` file for testing purposes (since RPC endpoint is not written yet, and pathfinder doesn't expose the endpoint either yet ([actually it does now](https://github.com/eqlabs/pathfinder/pull/787)).
- The `data.json` file was obtained by doing a curl on a modified version of pathfinder.
- `pathfinder` uses `starkhash` and here we use `FieldElement` so there's a bit of wrapping / translation going on.
- The verification is simply a method called on the `GetProofOutput` which should be easy to use in the future
- I have only added a `NonMembership` test because I don't have a contract to look at now. I believe this could come in a subsequent PR (and maybe create an associated issue to add more tests)