### PR TITLE
dev: remove precommit test all

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ default-features = false
 features = [
     "precommit-hook",
     "run-for-all",
-    "run-cargo-test",
     "run-cargo-clippy",
     "run-cargo-fmt",
 ]


### PR DESCRIPTION
Remove `cargo test --all` from pre-commit hooks via Husky 

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

the pre-commit hook generated by Husky will no longer generate lines for `cargo test --all`

Issue Number: N/A

# What is the new behavior?

- Husky would generate a pre-commit hook for `cargo test --all`

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information

In order to stop testing all for each commit you will need to manually edit the `.git/hooks/pre-commit` file and remove the lines pertaining to testing.
