### PR TITLE
feat: Starknet "get_block_with_tx_hashes"

### DIFF
--- a/beerus_cli/src/model.rs
+++ b/beerus_cli/src/model.rs
@@ -443,7 +443,7 @@ impl Display for CommandResponse {
                 write!(f, "{json_response}")
             }
 
-            // Print the current block hash and number.
+            // Print the block data with its transactions.
             // Result looks like: `
             CommandResponse::StarknetQueryBlockWithTxs(response) => {
                 write!(f, "Block hash: {response:?}")

--- a/beerus_cli/src/model.rs
+++ b/beerus_cli/src/model.rs
@@ -3,7 +3,9 @@ use ethers::types::{H256, U256};
 use helios::types::ExecutionBlock;
 use serde_json::json;
 use starknet::core::types::FieldElement;
-use starknet::providers::jsonrpc::models::{BlockHashAndNumber, ContractClass};
+use starknet::providers::jsonrpc::models::{
+    BlockHashAndNumber, ContractClass, MaybePendingBlockWithTxs,
+};
 use std::{fmt::Display, path::PathBuf};
 
 /// Main struct for the Beerus CLI args.
@@ -196,6 +198,16 @@ pub enum StarkNetSubCommands {
         #[arg(short, long, value_name = "CONTRACT_ADDRESS")]
         contract_address: String,
     },
+    QueryBlockWithTxs {
+        /// Type of block identifier
+        /// eg. hash, number, tag
+        #[arg(short, long, value_name = "BLOCK_ID_TYPE")]
+        block_id_type: String,
+        /// The block identifier
+        /// eg. 0x123, 123, pending, or latest
+        #[arg(short, long, value_name = "BLOCK_ID")]
+        block_id: String,
+    },
 }
 
 /// The response from a CLI command.
@@ -223,6 +235,7 @@ pub enum CommandResponse {
     StarknetQueryBlockHashAndNumber(BlockHashAndNumber),
     StarknetQueryGetClass(ContractClass),
     StarknetQueryGetClassAt(ContractClass),
+    StarknetQueryBlockWithTxs(MaybePendingBlockWithTxs),
     StarkNetL1ToL2MessageCancellations(U256),
     StarkNetL1ToL2Messages(U256),
     StarkNetL1ToL2MessageNonce(U256),
@@ -428,6 +441,12 @@ impl Display for CommandResponse {
                     }
                 );
                 write!(f, "{json_response}")
+            }
+
+            // Print the current block hash and number.
+            // Result looks like: `
+            CommandResponse::StarknetQueryBlockWithTxs(response) => {
+                write!(f, "Block hash: {response:?}")
             }
         }
     }

--- a/beerus_cli/src/runner.rs
+++ b/beerus_cli/src/runner.rs
@@ -139,6 +139,17 @@ pub async fn run(beerus: BeerusLightClient, cli: Cli) -> Result<CommandResponse>
                 )
                 .await
             }
+            StarkNetSubCommands::QueryBlockWithTxs {
+                block_id_type,
+                block_id,
+            } => {
+                starknet::query_block_with_txs(
+                    beerus,
+                    block_id_type.to_string(),
+                    block_id.to_string(),
+                )
+                .await
+            }
         },
     }
 }

--- a/beerus_cli/src/starknet/mod.rs
+++ b/beerus_cli/src/starknet/mod.rs
@@ -260,3 +260,25 @@ pub async fn get_class_at(
             .await?,
     ))
 }
+
+/// Query Block with Txs array
+/// # Arguments
+/// * `beerus` - The Beerus light client.
+/// * `block_id_type` - The type of block identifier.
+/// * `block_id` - The block identifier.
+/// # Returns
+/// * `Result<CommandResponse>` - The contract class definition.
+pub async fn query_block_with_txs(
+    beerus: BeerusLightClient,
+    block_id_type: String,
+    block_id: String,
+) -> Result<CommandResponse> {
+    let block_id =
+        beerus_core::starknet_helper::block_id_string_to_block_id_type(&block_id_type, &block_id)?;
+    Ok(CommandResponse::StarknetQueryBlockWithTxs(
+        beerus
+            .starknet_lightclient
+            .get_block_with_txs(&block_id)
+            .await?,
+    ))
+}

--- a/beerus_core/src/lightclient/starknet/mod.rs
+++ b/beerus_core/src/lightclient/starknet/mod.rs
@@ -6,7 +6,7 @@ use starknet::{
     core::types::FieldElement,
     providers::jsonrpc::{
         models::{
-            BlockHashAndNumber, BlockId, ContractClass, FunctionCall, MaybePendingBlockWithTxs,
+            BlockHashAndNumber, BlockId, ContractClass, FunctionCall, MaybePendingBlockWithTxHashes,
         },
         HttpTransport, JsonRpcClient,
     },
@@ -39,7 +39,10 @@ pub trait StarkNetLightClient: Send + Sync {
         block_id: &BlockId,
         contract_address: FieldElement,
     ) -> Result<ContractClass>;
-    async fn get_block_with_txs(&self, block_id: &BlockId) -> Result<MaybePendingBlockWithTxs>;
+    async fn get_block_with_tx_hashes(
+        &self,
+        block_id: &BlockId,
+    ) -> Result<MaybePendingBlockWithTxHashes>;
 }
 
 pub struct StarkNetLightClientImpl {
@@ -204,11 +207,14 @@ impl StarkNetLightClient for StarkNetLightClientImpl {
     ///
     /// # Returns
     ///
-    /// `Ok(MaybePendingBlockWithTxs)` if the operation was successful.
+    /// `Ok(MaybePendingBlockWithTxHashes)` if the operation was successful.
     /// `Err(eyre::Report)` if the operation failed.
-    async fn get_block_with_txs(&self, block_id: &BlockId) -> Result<MaybePendingBlockWithTxs> {
+    async fn get_block_with_tx_hashes(
+        &self,
+        block_id: &BlockId,
+    ) -> Result<MaybePendingBlockWithTxHashes> {
         self.client
-            .get_block_with_txs(block_id)
+            .get_block_with_tx_hashes(block_id)
             .await
             .map_err(|e| eyre::eyre!(e))
     }

--- a/beerus_core/tests/beerus.rs
+++ b/beerus_core/tests/beerus.rs
@@ -2258,8 +2258,7 @@ mod tests {
             .unwrap();
 
         // Then
-        // Assert that the contract class returned by the `get_block_with_txs` method of the Beerus light client
-        // is the expected contract class.
+        // Assert that the block data returned by the `get_block_with_txs` method of the Beerus light client
         assert_eq!(format!("{result:?}"), format!("{expected_value_value:?}"))
     }
 

--- a/beerus_core/tests/beerus.rs
+++ b/beerus_core/tests/beerus.rs
@@ -15,7 +15,9 @@ mod tests {
     use starknet::{
         core::types::FieldElement,
         macros::selector,
-        providers::jsonrpc::models::{BlockHashAndNumber, BlockId},
+        providers::jsonrpc::models::{
+            BlockHashAndNumber, BlockId, BlockStatus, BlockWithTxs, MaybePendingBlockWithTxs,
+        },
     };
     use std::str::FromStr;
 
@@ -2200,6 +2202,104 @@ mod tests {
         // Assert that the `get_class_at` method of the Beerus light client returns `Err`.
         assert!(result.is_err());
         // Assert that the error returned by the `get_class_at` method of the Beerus light client is the expected error.
+        assert_eq!(result.unwrap_err().to_string(), expected_error.to_string());
+        // Assert that the sync status of the Beerus light client is `SyncStatus::NotSynced`.
+        assert_eq!(beerus.sync_status().clone(), SyncStatus::NotSynced);
+    }
+
+    /// Test the `get_block_with_txs` method when everything is fine.
+    /// This test mocks external dependencies.
+    /// It does not test the `get_block_with_txs` method of the external dependencies.
+    /// It tests the `get_block_with_txs` method of the Beerus light client.
+    #[tokio::test]
+    async fn given_normal_conditions_when_call_get_block_with_txs_then_should_return_ok() {
+        // Given
+        // Mock config, ethereum light client and starknet light client.
+        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+
+        let status = BlockStatus::Pending;
+        let block_hash = FieldElement::from_dec_str("01").unwrap();
+        let parent_hash = FieldElement::from_dec_str("01").unwrap();
+        let block_number = 0;
+        let new_root = FieldElement::from_dec_str("01").unwrap();
+        let timestamp: u64 = 10;
+        let sequencer_address = FieldElement::from_dec_str("01").unwrap();
+        let transactions = vec![];
+        let block = BlockWithTxs {
+            status,
+            block_hash,
+            parent_hash,
+            block_number,
+            new_root,
+            timestamp,
+            sequencer_address,
+            transactions,
+        };
+        // Mock the `get_block_with_txs` method of the Starknet light client.
+        let expected_result = MaybePendingBlockWithTxs::Block(block);
+        let expected_value_value = expected_result.clone();
+
+        starknet_lightclient_mock
+            .expect_get_block_with_txs()
+            .return_once(move |_block_id| Ok(expected_result));
+
+        // When
+        let beerus = BeerusLightClient::new(
+            config.clone(),
+            Box::new(ethereum_lightclient_mock),
+            Box::new(starknet_lightclient_mock),
+        );
+
+        let block_id = BlockId::Hash(FieldElement::from_str("0x01").unwrap());
+        let result = beerus
+            .starknet_lightclient
+            .get_block_with_txs(&block_id)
+            .await
+            .unwrap();
+
+        // Then
+        // Assert that the contract class returned by the `get_block_with_txs` method of the Beerus light client
+        // is the expected contract class.
+        assert_eq!(format!("{result:?}"), format!("{expected_value_value:?}"))
+    }
+
+    /// Test the `get_block_with_txs` method when the StarkNet light client returns an error.
+    /// This test mocks external dependencies.
+    /// It does not test the `get_block_with_txs` method of the external dependencies.
+    /// It tests the `get_block_with_txs` method of the Beerus light client.
+    /// It tests the error handling of the `get_block_with_txs` method of the Beerus light client.
+    #[tokio::test]
+    async fn given_starknet_lightclient_error_when_call_get_block_with_txs_then_should_return_error(
+    ) {
+        // Given
+        // Mock config, ethereum light client and starknet light client.
+        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+
+        let expected_error = "StarkNet light client error";
+
+        // Mock the `get_block_with_txs` method of the StarkNet light client.
+        starknet_lightclient_mock
+            .expect_get_block_with_txs()
+            .times(1)
+            .return_once(move |_block_id| Err(eyre!(expected_error)));
+
+        // When
+        let beerus = BeerusLightClient::new(
+            config.clone(),
+            Box::new(ethereum_lightclient_mock),
+            Box::new(starknet_lightclient_mock),
+        );
+
+        let block_id = BlockId::Hash(FieldElement::from_str("0x01").unwrap());
+        let result = beerus
+            .starknet_lightclient
+            .get_block_with_txs(&block_id)
+            .await;
+
+        // Then
+        // Assert that the `get_block_with_txs` method of the Beerus light client returns `Err`.
+        assert!(result.is_err());
+        // Assert that the error returned by the `get_block_with_txs` method of the Beerus light client is the expected error.
         assert_eq!(result.unwrap_err().to_string(), expected_error.to_string());
         // Assert that the sync status of the Beerus light client is `SyncStatus::NotSynced`.
         assert_eq!(beerus.sync_status().clone(), SyncStatus::NotSynced);

--- a/beerus_core/tests/beerus.rs
+++ b/beerus_core/tests/beerus.rs
@@ -16,7 +16,8 @@ mod tests {
         core::types::FieldElement,
         macros::selector,
         providers::jsonrpc::models::{
-            BlockHashAndNumber, BlockId, BlockStatus, BlockWithTxs, MaybePendingBlockWithTxs,
+            BlockHashAndNumber, BlockId, BlockStatus, BlockWithTxHashes,
+            MaybePendingBlockWithTxHashes,
         },
     };
     use std::str::FromStr;
@@ -2207,12 +2208,12 @@ mod tests {
         assert_eq!(beerus.sync_status().clone(), SyncStatus::NotSynced);
     }
 
-    /// Test the `get_block_with_txs` method when everything is fine.
+    /// Test the `get_block_with_tx_hashes` method when everything is fine.
     /// This test mocks external dependencies.
-    /// It does not test the `get_block_with_txs` method of the external dependencies.
-    /// It tests the `get_block_with_txs` method of the Beerus light client.
+    /// It does not test the `get_block_with_tx_hashes` method of the external dependencies.
+    /// It tests the `get_block_with_tx_hashes` method of the Beerus light client.
     #[tokio::test]
-    async fn given_normal_conditions_when_call_get_block_with_txs_then_should_return_ok() {
+    async fn given_normal_conditions_when_call_get_block_with_tx_hashes_then_should_return_ok() {
         // Given
         // Mock config, ethereum light client and starknet light client.
         let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
@@ -2225,7 +2226,7 @@ mod tests {
         let timestamp: u64 = 10;
         let sequencer_address = FieldElement::from_dec_str("01").unwrap();
         let transactions = vec![];
-        let block = BlockWithTxs {
+        let block = BlockWithTxHashes {
             status,
             block_hash,
             parent_hash,
@@ -2235,12 +2236,12 @@ mod tests {
             sequencer_address,
             transactions,
         };
-        // Mock the `get_block_with_txs` method of the Starknet light client.
-        let expected_result = MaybePendingBlockWithTxs::Block(block);
+        // Mock the `get_block_with_tx_hashes` method of the Starknet light client.
+        let expected_result = MaybePendingBlockWithTxHashes::Block(block);
         let expected_value_value = expected_result.clone();
 
         starknet_lightclient_mock
-            .expect_get_block_with_txs()
+            .expect_get_block_with_tx_hashes()
             .return_once(move |_block_id| Ok(expected_result));
 
         // When
@@ -2253,22 +2254,22 @@ mod tests {
         let block_id = BlockId::Hash(FieldElement::from_str("0x01").unwrap());
         let result = beerus
             .starknet_lightclient
-            .get_block_with_txs(&block_id)
+            .get_block_with_tx_hashes(&block_id)
             .await
             .unwrap();
 
         // Then
-        // Assert that the block data returned by the `get_block_with_txs` method of the Beerus light client
+        // Assert that the block data returned by the `get_block_with_tx_hashes` method of the Beerus light client
         assert_eq!(format!("{result:?}"), format!("{expected_value_value:?}"))
     }
 
-    /// Test the `get_block_with_txs` method when the StarkNet light client returns an error.
+    /// Test the `get_block_with_tx_hashes` method when the StarkNet light client returns an error.
     /// This test mocks external dependencies.
-    /// It does not test the `get_block_with_txs` method of the external dependencies.
-    /// It tests the `get_block_with_txs` method of the Beerus light client.
-    /// It tests the error handling of the `get_block_with_txs` method of the Beerus light client.
+    /// It does not test the `get_block_with_tx_hashes` method of the external dependencies.
+    /// It tests the `get_block_with_tx_hashes` method of the Beerus light client.
+    /// It tests the error handling of the `get_block_with_tx_hashes` method of the Beerus light client.
     #[tokio::test]
-    async fn given_starknet_lightclient_error_when_call_get_block_with_txs_then_should_return_error(
+    async fn given_starknet_lightclient_error_when_call_get_block_with_tx_hashes_then_should_return_error(
     ) {
         // Given
         // Mock config, ethereum light client and starknet light client.
@@ -2276,9 +2277,9 @@ mod tests {
 
         let expected_error = "StarkNet light client error";
 
-        // Mock the `get_block_with_txs` method of the StarkNet light client.
+        // Mock the `get_block_with_tx_hashes` method of the StarkNet light client.
         starknet_lightclient_mock
-            .expect_get_block_with_txs()
+            .expect_get_block_with_tx_hashes()
             .times(1)
             .return_once(move |_block_id| Err(eyre!(expected_error)));
 
@@ -2292,13 +2293,13 @@ mod tests {
         let block_id = BlockId::Hash(FieldElement::from_str("0x01").unwrap());
         let result = beerus
             .starknet_lightclient
-            .get_block_with_txs(&block_id)
+            .get_block_with_tx_hashes(&block_id)
             .await;
 
         // Then
-        // Assert that the `get_block_with_txs` method of the Beerus light client returns `Err`.
+        // Assert that the `get_block_with_tx_hashes` method of the Beerus light client returns `Err`.
         assert!(result.is_err());
-        // Assert that the error returned by the `get_block_with_txs` method of the Beerus light client is the expected error.
+        // Assert that the error returned by the `get_block_with_tx_hashes` method of the Beerus light client is the expected error.
         assert_eq!(result.unwrap_err().to_string(), expected_error.to_string());
         // Assert that the sync status of the Beerus light client is `SyncStatus::NotSynced`.
         assert_eq!(beerus.sync_status().clone(), SyncStatus::NotSynced);

--- a/beerus_rest_api/src/api/starknet/resp/mod.rs
+++ b/beerus_rest_api/src/api/starknet/resp/mod.rs
@@ -82,3 +82,9 @@ pub struct QueryGetClassAtResponse {
     pub entry_points_by_type: Value,
     pub program: String,
 }
+
+#[derive(Serialize, JsonSchema)]
+#[serde(crate = "rocket::serde")]
+pub struct QueryBlockWithTxsResponse {
+    pub block_with_txs: String,
+}

--- a/beerus_rest_api/src/lib.rs
+++ b/beerus_rest_api/src/lib.rs
@@ -41,6 +41,7 @@ pub async fn build_rocket_server(beerus: BeerusLightClient) -> Rocket<Build> {
             starknet::endpoints::query_starknet_block_hash_and_number,
             starknet::endpoints::get_class,
             starknet::endpoints::get_class_at,
+            starknet::endpoints::get_block_with_txs,
         ],
     )
 }

--- a/beerus_rest_api/tests/api.rs
+++ b/beerus_rest_api/tests/api.rs
@@ -14,7 +14,12 @@ mod test {
     use ethers::types::{H256, U256};
     use helios::types::{ExecutionBlock, Transactions};
     use rocket::{http::Status, local::asynchronous::Client, uri};
-    use starknet::{core::types::FieldElement, providers::jsonrpc::models::BlockHashAndNumber};
+    use starknet::{
+        core::types::FieldElement,
+        providers::jsonrpc::models::{
+            BlockHashAndNumber, BlockStatus, BlockWithTxs, MaybePendingBlockWithTxs,
+        },
+    };
 
     /// Test the `send_raw_transaction` endpoint.
     /// `/ethereum/send_raw_transaction/<bytes>`
@@ -2093,6 +2098,104 @@ mod test {
             .get(uri!(
                 "/starknet/contract/class_at/0x123?block_id=123&block_id_type=number"
             ))
+            .dispatch()
+            .await;
+
+        // Then
+        assert_eq!(response.status(), Status::InternalServerError);
+        assert_eq!(
+            response.into_string().await.unwrap(),
+            "{\"error_message\":\"cannot query starknet contract class\"}"
+        );
+    }
+
+    /// Test the `get_block_with_txs` endpoint.
+    /// `/starknet/block_with_txs/<block_id>?<block_id_type>`
+    /// Given normal conditions, when query starknet get_block_with_txs, then ok.
+    #[tokio::test]
+    async fn given_normal_conditions_when_get_block_with_txs_then_ok() {
+        // Build mocks.
+        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+
+        let status = BlockStatus::Pending;
+        let block_hash = FieldElement::from_dec_str("01").unwrap();
+        let parent_hash = FieldElement::from_dec_str("01").unwrap();
+        let block_number = 0;
+        let new_root = FieldElement::from_dec_str("01").unwrap();
+        let timestamp: u64 = 10;
+        let sequencer_address = FieldElement::from_dec_str("01").unwrap();
+        let transactions = vec![];
+        let block = BlockWithTxs {
+            status,
+            block_hash,
+            parent_hash,
+            block_number,
+            new_root,
+            timestamp,
+            sequencer_address,
+            transactions,
+        };
+        // Mock the `get_block_with_txs` method of the Starknet light client.
+        let expected_result = MaybePendingBlockWithTxs::Block(block);
+
+        // Set the expected return value for the StarkNet light client mock.
+        starknet_lightclient
+            .expect_get_block_with_txs()
+            .return_once(move |_block_id| Ok(expected_result));
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+        let client = Client::tracked(build_rocket_server(beerus).await)
+            .await
+            .expect("valid rocket instance");
+
+        // When
+        let response = client
+            .get(uri!("/starknet/block_with_txs/123?block_id_type=number"))
+            .dispatch()
+            .await;
+
+        // Then
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(
+            response.into_string().await.unwrap(),
+            "{\"block_with_txs\":\"Block(BlockWithTxs { status: Pending, block_hash: FieldElement { inner: 0x0000000000000000000000000000000000000000000000000000000000000001 }, parent_hash: FieldElement { inner: 0x0000000000000000000000000000000000000000000000000000000000000001 }, block_number: 0, new_root: FieldElement { inner: 0x0000000000000000000000000000000000000000000000000000000000000001 }, timestamp: 10, sequencer_address: FieldElement { inner: 0x0000000000000000000000000000000000000000000000000000000000000001 }, transactions: [] })\"}",
+        );
+    }
+
+    /// Test the `get_block_with_txs` endpoint.
+    /// `/starknet/get_block_with_txs/<block_id>?<block_id_type>`
+    /// Given StarkNet light client returns error when query starknet get_block_with_txs, then error is propagated.
+    #[tokio::test]
+    async fn given_starknet_ligthclient_returns_error_when_get_block_with_txs_then_error_is_propagated(
+    ) {
+        // Build mocks.
+        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+
+        // Given
+
+        // Set the expected return value for the StarkNet light client mock.
+        starknet_lightclient
+            .expect_get_block_with_txs()
+            .return_once(move |_block_id| Err(eyre::eyre!("cannot query starknet contract class")));
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+
+        // Build the Rocket instance.
+        let client = Client::tracked(build_rocket_server(beerus).await)
+            .await
+            .expect("valid rocket instance");
+
+        // When
+        let response = client
+            .get(uri!("/starknet/block_with_txs/123?block_id_type=number"))
             .dispatch()
             .await;
 

--- a/beerus_rest_api/tests/api.rs
+++ b/beerus_rest_api/tests/api.rs
@@ -2180,7 +2180,7 @@ mod test {
         // Set the expected return value for the StarkNet light client mock.
         starknet_lightclient
             .expect_get_block_with_txs()
-            .return_once(move |_block_id| Err(eyre::eyre!("cannot query starknet contract class")));
+            .return_once(move |_block_id| Err(eyre::eyre!("cannot query starknet block with txs")));
 
         let beerus = BeerusLightClient::new(
             config,
@@ -2203,7 +2203,7 @@ mod test {
         assert_eq!(response.status(), Status::InternalServerError);
         assert_eq!(
             response.into_string().await.unwrap(),
-            "{\"error_message\":\"cannot query starknet contract class\"}"
+            "{\"error_message\":\"cannot query starknet block with txs\"}"
         );
     }
 


### PR DESCRIPTION
- Added get_block_with_tx_hashes at CLI command.
- Added a new endpoint to fetch the block data and the txs hashes on the Starknet Network
- Implemented tests for Cli, Core and RestAPI
- Updated ethers library

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
