### PR TITLE
feat: Starknet "get_transaction_by_block_id_and_index"

### DIFF
--- a/beerus_cli/src/model.rs
+++ b/beerus_cli/src/model.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use starknet::core::types::FieldElement;
 use starknet::providers::jsonrpc::models::{
     BlockHashAndNumber, ContractClass, DeployTransactionResult, InvokeTransactionResult,
-    MaybePendingBlockWithTxs, StateUpdate, SyncStatusType,
+    MaybePendingBlockWithTxs, StateUpdate, SyncStatusType, Transaction,
 };
 use std::{fmt::Display, path::PathBuf};
 
@@ -323,6 +323,20 @@ pub enum StarkNetSubCommands {
         #[arg(short, long, value_name = "BLOCK_ID")]
         block_id: String,
     },
+    QueryTransactionByBlockIdAndIndex {
+        /// Type of block identifier
+        /// eg. hash, number, tag
+        #[arg(short, long, value_name = "BLOCK_ID_TYPE")]
+        block_id_type: String,
+        /// The block identifier
+        /// eg. 0x123, 123, pending, or latest
+        #[arg(short, long, value_name = "BLOCK_ID")]
+        block_id: String,
+        /// The Transaction Index
+        /// eg. 0,1,2,3,
+        #[arg(short, long, value_name = "INDEX")]
+        index: String,
+    },
 }
 
 /// The response from a CLI command.
@@ -363,6 +377,7 @@ pub enum CommandResponse {
     StarkNetL1ToL2Messages(U256),
     StarkNetL1ToL2MessageNonce(U256),
     StarkNetL2ToL1Messages(U256),
+    StarknetQueryTransactionByBlockIdAndIndex(Transaction),
 }
 
 /// Display implementation for the CLI command response.
@@ -647,6 +662,11 @@ impl Display for CommandResponse {
             // Result looks like: `
             CommandResponse::StarknetQueryBlockWithTxs(response) => {
                 write!(f, "Block hash: {response:?}")
+            }
+            // Print the Transaction data
+            // Result looks like:
+            CommandResponse::StarknetQueryTransactionByBlockIdAndIndex(transaction) => {
+                write!(f, "Transaction: {transaction:?}")
             }
         }
     }

--- a/beerus_cli/src/runner.rs
+++ b/beerus_cli/src/runner.rs
@@ -231,6 +231,19 @@ pub async fn run(beerus: BeerusLightClient, cli: Cli) -> Result<CommandResponse>
                 )
                 .await
             }
+            StarkNetSubCommands::QueryTransactionByBlockIdAndIndex {
+                block_id_type,
+                block_id,
+                index,
+            } => {
+                starknet::get_transaction_by_block_id_and_index(
+                    beerus,
+                    block_id_type.to_string(),
+                    block_id.to_string(),
+                    index.to_string(),
+                )
+                .await
+            }
         },
     }
 }

--- a/beerus_cli/src/starknet/mod.rs
+++ b/beerus_cli/src/starknet/mod.rs
@@ -461,3 +461,27 @@ pub async fn query_block_with_txs(
             .await?,
     ))
 }
+
+/// Query the number of transactions in a block given a block id of the StarkNet network.
+/// # Arguments
+/// * `beerus` - The Beerus light client.
+/// * `block_id_type` - The type of block identifier.
+/// * `block_id` - The block identifier.
+/// # Returns
+/// * `Result<CommandResponse>` - The number of transactions in a block.
+pub async fn get_transaction_by_block_id_and_index(
+    beerus: BeerusLightClient,
+    block_id_type: String,
+    block_id: String,
+    index: String,
+) -> Result<CommandResponse> {
+    let index = u64::from_str(&index)?;
+    let block_id =
+        beerus_core::starknet_helper::block_id_string_to_block_id_type(&block_id_type, &block_id)?;
+    Ok(CommandResponse::StarknetQueryTransactionByBlockIdAndIndex(
+        beerus
+            .starknet_lightclient
+            .get_transaction_by_block_id_and_index(&block_id, index)
+            .await?,
+    ))
+}

--- a/beerus_cli/tests/cli.rs
+++ b/beerus_cli/tests/cli.rs
@@ -22,8 +22,9 @@ mod test {
         core::types::FieldElement,
         providers::jsonrpc::models::{
             BlockHashAndNumber, BlockStatus, BlockWithTxs, ContractClass, ContractEntryPoint,
-            DeployTransactionResult, EntryPointsByType, InvokeTransactionResult,
-            MaybePendingBlockWithTxs, StateDiff, StateUpdate,
+            DeployTransactionResult, EntryPointsByType, InvokeTransaction, InvokeTransactionResult,
+            InvokeTransactionV0, MaybePendingBlockWithTxs, StateDiff, StateUpdate,
+            Transaction as StarknetTransaction,
         },
     };
 
@@ -2844,6 +2845,108 @@ mod test {
         }
     }
 
+    /// Test the `get_transaction_by_block_id_and_index` CLI command.
+    /// Given normal conditions, when query get_transaction_by_block_id_and_index, then ok.
+    #[tokio::test]
+    async fn given_normal_conditions_when_starknet_get_transaction_by_block_id_and_index_then_ok() {
+        // Build mocks.
+        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+
+        // Mock the `get_transaction_by_block_id_and_index` method of the Starknet light client.
+        let transaction_hash = FieldElement::from_str("0x01").unwrap();
+        let max_fee = FieldElement::from_str("0x01").unwrap();
+        let signature = vec![];
+        let nonce = FieldElement::from_str("0x01").unwrap();
+        let contract_address = FieldElement::from_str("0x01").unwrap();
+        let entry_point_selector = FieldElement::from_str("0x01").unwrap();
+        let calldata = vec![];
+
+        let invoke_transaction = InvokeTransactionV0 {
+            transaction_hash,
+            max_fee,
+            signature,
+            nonce,
+            contract_address,
+            entry_point_selector,
+            calldata,
+        };
+
+        let expected_result =
+            StarknetTransaction::Invoke(InvokeTransaction::V0(invoke_transaction));
+        let expected_result_value = expected_result.clone();
+        // Set the expected return value for the StarkNet light client mock.
+        starknet_lightclient
+            .expect_get_transaction_by_block_id_and_index()
+            .return_once(move |_block_id, _index| Ok(expected_result));
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+
+        // Mock the command line arguments.
+        let cli = Cli {
+            config: None,
+            command: Commands::StarkNet(StarkNetCommands {
+                command: StarkNetSubCommands::QueryTransactionByBlockIdAndIndex {
+                    block_id_type: "number".to_string(),
+                    block_id: "123".to_string(),
+                    index: "0".to_string(),
+                },
+            }),
+        };
+        // When
+        let result = runner::run(beerus, cli).await.unwrap();
+
+        // Then
+        assert_eq!(
+            format!("Transaction: {expected_result_value:?}"),
+            result.to_string()
+        );
+    }
+
+    /// Test the `get_transaction_by_block_id_and_index` CLI command.
+    /// Given starknet lightclient returns an error, when query get_transaction_by_block_id_and_index, then the error is propagated.
+    /// Error case.
+    #[tokio::test]
+    async fn given_starknet_lightclient_returns_error_when_starknet_get_transaction_by_block_id_and_index_then_error_is_propagated(
+    ) {
+        // Build mocks.
+        let (config, ethereum_lightclient, mut starknet_lightclient) = config_and_mocks();
+
+        // Given
+        // Set the expected return value for the StarkNet light client mock.
+        starknet_lightclient
+            .expect_get_transaction_by_block_id_and_index()
+            .return_once(move |_block_id, _index| Err(eyre::eyre!("starknet_lightclient_error")));
+
+        let beerus = BeerusLightClient::new(
+            config,
+            Box::new(ethereum_lightclient),
+            Box::new(starknet_lightclient),
+        );
+
+        // Mock the command line arguments.
+        let cli = Cli {
+            config: None,
+            command: Commands::StarkNet(StarkNetCommands {
+                command: StarkNetSubCommands::QueryTransactionByBlockIdAndIndex {
+                    block_id_type: "number".to_string(),
+                    block_id: "123".to_string(),
+                    index: "0".to_string(),
+                },
+            }),
+        };
+        // When
+        let result = runner::run(beerus, cli).await;
+
+        // Then
+        match result {
+            Err(e) => assert_eq!("starknet_lightclient_error", e.to_string()),
+            Ok(_) => panic!("Expected error, got ok"),
+        }
+    }
     fn config_and_mocks() -> (Config, MockEthereumLightClient, MockStarkNetLightClient) {
         let config = Config {
             ethereum_network: "mainnet".to_string(),

--- a/beerus_core/src/lightclient/starknet/mod.rs
+++ b/beerus_core/src/lightclient/starknet/mod.rs
@@ -8,7 +8,7 @@ use starknet::{
         models::{
             BlockHashAndNumber, BlockId, BroadcastedDeployTransaction,
             BroadcastedInvokeTransaction, ContractClass, DeployTransactionResult,
-            InvokeTransactionResult, MaybePendingBlockWithTxs, SyncStatusType,
+            InvokeTransactionResult, MaybePendingBlockWithTxs, SyncStatusType, Transaction,
         },
         models::{FunctionCall, StateUpdate},
         HttpTransport, JsonRpcClient,
@@ -60,6 +60,11 @@ pub trait StarkNetLightClient: Send + Sync {
         deploy_transaction: &BroadcastedDeployTransaction,
     ) -> Result<DeployTransactionResult>;
     async fn get_block_with_txs(&self, block_id: &BlockId) -> Result<MaybePendingBlockWithTxs>;
+    async fn get_transaction_by_block_id_and_index(
+        &self,
+        block_id: &BlockId,
+        index: u64,
+    ) -> Result<Transaction>;
 }
 
 pub struct StarkNetLightClientImpl {
@@ -345,6 +350,28 @@ impl StarkNetLightClient for StarkNetLightClientImpl {
     async fn get_block_with_txs(&self, block_id: &BlockId) -> Result<MaybePendingBlockWithTxs> {
         self.client
             .get_block_with_txs(block_id)
+            .await
+            .map_err(|e| eyre::eyre!(e))
+    }
+
+    /// Get the transaction given a block id and index
+    /// The number of transactions in a block.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_id` - The block identifier.
+    /// * `index` - Transaction index
+    /// # Returns
+    ///
+    /// `Ok(Transaction)` if the operation was successful.
+    /// `Err(eyre::Report)` if the operation failed.
+    async fn get_transaction_by_block_id_and_index(
+        &self,
+        block_id: &BlockId,
+        index: u64,
+    ) -> Result<Transaction> {
+        self.client
+            .get_transaction_by_block_id_and_index(block_id, index)
             .await
             .map_err(|e| eyre::eyre!(e))
     }

--- a/beerus_rest_api/src/api/starknet/resp/mod.rs
+++ b/beerus_rest_api/src/api/starknet/resp/mod.rs
@@ -184,3 +184,9 @@ pub struct AddDeployTransactionResponse {
 pub struct QueryBlockWithTxsResponse {
     pub block_with_txs: String,
 }
+
+#[derive(Serialize, JsonSchema)]
+#[serde(crate = "rocket::serde")]
+pub struct QueryTransactionByBlockIdAndIndex {
+    pub transaction_data: String,
+}

--- a/beerus_rest_api/src/lib.rs
+++ b/beerus_rest_api/src/lib.rs
@@ -50,6 +50,7 @@ pub async fn build_rocket_server(beerus: BeerusLightClient) -> Rocket<Build> {
             starknet::endpoints::add_invoke_transaction,
             starknet::endpoints::add_deploy_transaction,
             starknet::endpoints::get_block_with_txs,
+            starknet::endpoints::get_transaction_by_block_id_and_index,
         ],
     )
 }


### PR DESCRIPTION
- Added get_transaction_by_block_id_and_index CLI command.
- Added a new endpoint to fetch a transaction given a block id and index on the Starknet Network
- Implemented tests for Cli, Core and RestAPI
- Updated ethers library
# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #151 

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
