### PR TITLE
dev: workspace run top level binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,14 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "beerus"
-version = "0.1.0"
-dependencies = [
- "beerus_core",
- "cargo-husky",
-]
-
-[[package]]
 name = "beerus-rpc"
 version = "0.1.0"
 dependencies = [
@@ -529,6 +521,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.20.0",
  "beerus_core",
+ "cargo-husky",
  "clap",
  "env_logger 0.10.0",
  "ethers",
@@ -547,6 +540,7 @@ name = "beerus_core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cargo-husky",
  "ethers",
  "eyre",
  "helios",
@@ -568,6 +562,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.20.0",
  "beerus_core",
+ "cargo-husky",
  "env_logger 0.9.3",
  "ethers",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,30 +1,12 @@
-[package]
-name = "beerus"
-version = "0.1.0"
-edition = "2021"
-
 [workspace]
 members = ["beerus_core", "beerus_cli", "beerus_rest_api", "beerus-rpc"]
 
 [workspace.package]
+version = "0.1.0"
 edition = "2021"
-authors = ["Abdelhamid Bakhta <@abdelhamidbakhta>", "Lucas Levy <@lucaslvy>"]
-description = "A fast, secure and portable light client for StarkNet"
-homepage = "https://github.com/starknet-exploration/beerus"
-repository = "https://github.com/starknet-exploration/beerus"
-readme = "./README.md"
+repository = "https://github.com/keep-starknet-strange/beerus"
 license = "MIT"
+license-file = "LICENSE"
 
-
-[dependencies]
+[workspace.dependencies]
 beerus_core = { path = "./beerus_core" }
-
-[dev-dependencies.cargo-husky]
-version = "1.5.0"
-default-features = false
-features = [
-    "precommit-hook",
-    "run-for-all",
-    "run-cargo-clippy",
-    "run-cargo-fmt",
-]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ Meanwhile you can just use unit tests to dev.
 cargo test --all
 ```
 
+Run binary:
+
+```bash
+source .env && cargo run --bin beerus_rest_api
+```
+
+Run binary verbose:
+
+```bash
+source .env && RUST_LOG=info cargo run --bin beerus_rest_api
+```
+
 Build from source:
 
 ```bash

--- a/beerus_cli/Cargo.toml
+++ b/beerus_cli/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "beerus_cli"
-version = "0.1.0"
+description = "CLI for interacting with the Beerus Light Client"
+version.workspace = true
 edition.workspace = true
-description.workspace = true
-homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
 
 [dependencies]
-beerus_core = { path = "../beerus_core" }
+beerus_core.workspace = true
 helios = { git = "https://github.com/a16z/helios" }
 ethers = "1.0.2"
 primitive-types = "0.11.1"
@@ -19,3 +20,17 @@ starknet = { git = "https://github.com/xJonathanLEI/starknet-rs" }
 serde_json = "1.0.91"
 base64 = "0.20.0"
 serde = "1.0.152"
+
+[dev-dependencies.cargo-husky]
+version = "1.5.0"
+default-features = false
+features = [
+    "precommit-hook",
+    "run-for-all",
+    "run-cargo-clippy",
+    "run-cargo-fmt",
+]
+
+[[bin]]
+name = "beerus_cli"
+path = "src/main.rs"

--- a/beerus_cli/Cargo.toml
+++ b/beerus_cli/Cargo.toml
@@ -30,7 +30,3 @@ features = [
     "run-cargo-clippy",
     "run-cargo-fmt",
 ]
-
-[[bin]]
-name = "beerus_cli"
-path = "src/main.rs"

--- a/beerus_core/Cargo.toml
+++ b/beerus_core/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "beerus_core"
-version = "0.1.0"
+description = "Core utilities of the Beerus Light Client"
+version.workspace = true
 edition.workspace = true
-description.workspace = true
-homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+
 
 [dependencies]
 async-trait = "0.1.58"
@@ -22,3 +24,13 @@ tokio = { version = "1.21.2", features = ["macros"] }
 [dev-dependencies]
 httpmock = "0.6.7"
 temp-env = "0.3.1"
+
+[dev-dependencies.cargo-husky]
+version = "1.5.0"
+default-features = false
+features = [
+    "precommit-hook",
+    "run-for-all",
+    "run-cargo-clippy",
+    "run-cargo-fmt",
+]

--- a/beerus_rest_api/Cargo.toml
+++ b/beerus_rest_api/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "beerus_rest_api"
-version = "0.1.0"
+description = "soon deprecated for JSON-RPC"
+version.workspace = true
 edition.workspace = true
-description.workspace = true
-homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
 
 [dependencies]
-beerus_core = { path = "../beerus_core" }
+beerus_core.workspace = true
 helios = { git = "https://github.com/a16z/helios" }
 ethers = "1.0.2"
 primitive-types = "0.11.1"
@@ -21,3 +22,13 @@ tokio = { version = "1.21.2", features = ["macros"] }
 rocket_okapi = { git = "https://github.com/GREsau/okapi", rev = "b5b0a89b273f04342d1cb615fef0642beef33cef" }
 schemars = "0.8.11"
 base64 = "0.20.0"
+
+[dev-dependencies.cargo-husky]
+version = "1.5.0"
+default-features = false
+features = [
+    "precommit-hook",
+    "run-for-all",
+    "run-cargo-clippy",
+    "run-cargo-fmt",
+]


### PR DESCRIPTION
Moved workspace declarations including:
- name
- description
- husky dev dependencies
- [[bin]] 

Into the crates.

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

must change directory into a crate in order to run

Issue Number: N/A

# What is the new behavior?

ability to run --bin <binary_name> from the top level dir

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
