### PR TITLE
dev: cache key for dependencies are not fork dependent

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
           shared-key: beerus-check
           cache-on-failure: true
 
-        uses: actions-rs/clippy-check@v1
+      - uses: actions-rs/clippy-check@v1
         with:
           # args: --all --all-features
           args: -- -D warnings

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: rustup update --no-self-update --profil=minimal stable
+        run: rustup update --no-self-update --profile=minimal stable
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: rustup update --no-self-update --profil=minimal stable
+        run: rustup update --no-self-update --profile=minimal stable
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: rustup update --no-self-update --profil=minimal stable
+        run: rustup update --no-self-update --profile=minimal stable
           
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,10 @@ jobs:
           rustup component add rustfmt
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: beerus-check
+          cache-on-failure: true
+
       - run: cargo fmt --check
 
   clippy:
@@ -36,6 +40,9 @@ jobs:
           rustup component add clippy
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: beerus-check
+          cache-on-failure: true
       # TODO: cleanup for
       # cargo clippy --all-features and --all-targets -- -D warnings
       - run: cargo clippy -- -D warnings
@@ -52,4 +59,9 @@ jobs:
           rustup default stable
           
       - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: beerus-check
+          cache-on-failure: true
+          
       - run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: rustup update --no-self-update --profile=minimal stable
+        run: |
+          rustup set profile minimal
+          rustup update --no-self-update stable
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -28,7 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: rustup update --no-self-update --profile=minimal stable
+        run: |
+          rustup set profile minimal
+          rustup update --no-self-update stable
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -44,7 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: rustup update --no-self-update --profile=minimal stable
+        run: |
+          rustup set profile minimal
+          rustup update --no-self-update stable
           
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: beerus-check
+          key: beerus-check
           cache-on-failure: true
 
       - run: cargo fmt --check
@@ -41,7 +41,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: beerus-check
+          key: beerus-check
           cache-on-failure: true
       # TODO: cleanup for
       # cargo clippy --all-features and --all-targets -- -D warnings
@@ -61,7 +61,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: beerus-check
+          key: beerus-check
           cache-on-failure: true
           
       - run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,6 @@ jobs:
           rustup default stable
           
       - uses: Swatinem/rust-cache@v2
-      - uses: Swatinem/rust-cache@v2
         with:
           shared-key: beerus-check
           cache-on-failure: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# TODO: add llvm codecov when we beerus-rpc testing 
+# TODO: add back llvm codecov when we beerus-rpc testing 
 jobs:
   check:
     name: check
@@ -21,48 +21,43 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: beerus-check
           cache-on-failure: true
 
       - run: cargo fmt --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install toolchain
+        run: |
+          rustup set profile minimal
+          rustup update --no-self-update stable
+          rustup default stable
+          rustup component add clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          
+      # TODO: cleanup for
+      # cargo clippy --all-features and --all-targets -- -D warnings
       - run: cargo clippy -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install toolchain
+        run: |
+          rustup set profile minimal
+          rustup update --no-self-update stable
+          rustup default stable
+          
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          
       - run: cargo test
-
-  # clippy:
-  #   name: clippy
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: install toolchain
-  #       run: |
-  #         rustup set profile minimal
-  #         rustup update --no-self-update stable
-  #         rustup default stable
-  #         rustup component add clippy
-
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         shared-key: beerus-check
-  #         cache-on-failure: true
-          
-  #     # TODO: cleanup for
-  #     # cargo clippy --all-features and --all-targets -- -D warnings
-  #     - run: cargo clippy -- -D warnings
-
-  # test:
-  #   name: test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: install toolchain
-  #       run: |
-  #         rustup set profile minimal
-  #         rustup update --no-self-update stable
-  #         rustup default stable
-          
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         shared-key: beerus-check
-  #         cache-on-failure: true
-          
-  #     - run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,9 +43,12 @@ jobs:
         with:
           shared-key: beerus-check
           cache-on-failure: true
-      # TODO: cleanup for
-      # cargo clippy --all-features and --all-targets -- -D warnings
-      - run: cargo clippy -- -D warnings
+
+        uses: actions-rs/clippy-check@v1
+        with:
+          # args: --all --all-features
+          args: -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,6 @@ jobs:
           rustup set profile minimal
           rustup update --no-self-update stable
           rustup default stable
-          rustup component add rustfmt
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -26,44 +25,44 @@ jobs:
           cache-on-failure: true
 
       - run: cargo fmt --check
-
-  clippy:
-    name: clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: install toolchain
-        run: |
-          rustup set profile minimal
-          rustup update --no-self-update stable
-          rustup default stable
-          rustup component add clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: beerus-check
-          cache-on-failure: true
-
-      - uses: actions-rs/clippy-check@v1
-        with:
-          # args: --all --all-features
-          args: -- -D warnings
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  test:
-    name: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: install toolchain
-        run: |
-          rustup set profile minimal
-          rustup update --no-self-update stable
-          rustup default stable
-          
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: beerus-check
-          cache-on-failure: true
-          
+      - run: cargo clippy -- -D warnings
       - run: cargo test
+
+  # clippy:
+  #   name: clippy
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: install toolchain
+  #       run: |
+  #         rustup set profile minimal
+  #         rustup update --no-self-update stable
+  #         rustup default stable
+  #         rustup component add clippy
+
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         shared-key: beerus-check
+  #         cache-on-failure: true
+          
+  #     # TODO: cleanup for
+  #     # cargo clippy --all-features and --all-targets -- -D warnings
+  #     - run: cargo clippy -- -D warnings
+
+  # test:
+  #   name: test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: install toolchain
+  #       run: |
+  #         rustup set profile minimal
+  #         rustup update --no-self-update stable
+  #         rustup default stable
+          
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         shared-key: beerus-check
+  #         cache-on-failure: true
+          
+  #     - run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,8 +8,8 @@ concurrency:
 
 # TODO: add back llvm codecov when we beerus-rpc testing 
 jobs:
-  check:
-    name: check
+  test:
+    name: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,12 +17,12 @@ jobs:
         run: |
           rustup set profile minimal
           rustup update --no-self-update stable
-
+          
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - run: cargo fmt --check
+          
+      - run: cargo test -- -q --test-threads=2
 
   clippy:
     name: clippy
@@ -42,8 +42,8 @@ jobs:
       # cargo clippy --all-features and --all-targets -- -D warnings
       - run: cargo clippy -- -D warnings
 
-  test:
-    name: test
+  check:
+    name: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -51,9 +51,9 @@ jobs:
         run: |
           rustup set profile minimal
           rustup update --no-self-update stable
-          
+
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          
-      - run: cargo test -- -q
+
+      - run: cargo fmt --check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,4 +56,4 @@ jobs:
         with:
           cache-on-failure: true
           
-      - run: cargo test
+      - run: cargo test -- -q

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# TODO: add back llvm codecov when we beerus-rpc testing 
+# TODO: add llvm codecov when we beerus-rpc testing 
 jobs:
   check:
     name: check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: beerus-check
+          shared-key: beerus-check
           cache-on-failure: true
 
       - run: cargo fmt --check
@@ -41,7 +41,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: beerus-check
+          shared-key: beerus-check
           cache-on-failure: true
       # TODO: cleanup for
       # cargo clippy --all-features and --all-targets -- -D warnings
@@ -61,7 +61,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          key: beerus-check
+          shared-key: beerus-check
           cache-on-failure: true
           
       - run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,10 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: |
-          rustup set profile minimal
-          rustup update --no-self-update stable
-          rustup default stable
+        run: rustup update --no-self-update --profil=minimal stable
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -31,11 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: |
-          rustup set profile minimal
-          rustup update --no-self-update stable
-          rustup default stable
-          rustup component add clippy
+        run: rustup update --no-self-update --profil=minimal stable
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -51,10 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install toolchain
-        run: |
-          rustup set profile minimal
-          rustup update --no-self-update stable
-          rustup default stable
+        run: rustup update --no-self-update --profil=minimal stable
           
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,11 @@ jobs:
         run: |
           rustup set profile minimal
           rustup update --no-self-update stable
-          rustup default stable
           
       - name: Cache Deps
         uses: Swatinem/rust-cache@v2
         with:
-          
+          cache-on-failure: true
 
       - name: Build
         run: cargo build --release --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           
       - name: Cache Deps
         uses: Swatinem/rust-cache@v2
+        with:
+          
 
       - name: Build
         run: cargo build --release --locked

--- a/crates/beerus-cli/tests/cli.rs
+++ b/crates/beerus-cli/tests/cli.rs
@@ -45,7 +45,7 @@ mod test {
         // Build mocks.
         let (config, mut ethereum_lightclient, starknet_lightclient) = config_and_mocks();
         let expected_value =
-            H256::from_str("0x9bb964b3fe087354bc1c1904518acc2b9df7ebedcb89215e9f3b41f47b6c31d")
+            H256::from_str("0xc9bb964b3fe087354bc1c1904518acc2b9df7ebedcb89215e9f3b41f47b6c31d")
                 .unwrap();
         // Given
         // Mock dependencies.

--- a/crates/beerus-cli/tests/cli.rs
+++ b/crates/beerus-cli/tests/cli.rs
@@ -45,7 +45,7 @@ mod test {
         // Build mocks.
         let (config, mut ethereum_lightclient, starknet_lightclient) = config_and_mocks();
         let expected_value =
-            H256::from_str("0xc9bb964b3fe087354bc1c1904518acc2b9df7ebedcb89215e9f3b41f47b6c31d")
+            H256::from_str("0x9bb964b3fe087354bc1c1904518acc2b9df7ebedcb89215e9f3b41f47b6c31d")
                 .unwrap();
         // Given
         // Mock dependencies.


### PR DESCRIPTION
dev: cache key for dependencies are not fork dependent

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

fresh dependency fetch/compile for each fork ci run

Issue Number: N/A

# What is the new behavior?

should use dependency cache across fork PRs
