### PR TITLE
feat: migrate Starknet: add_deploy_transaction to beerus-rpc

### DIFF
--- a/crates/beerus-rpc/src/api.rs
+++ b/crates/beerus-rpc/src/api.rs
@@ -8,8 +8,9 @@ use ethers::types::U256;
 use starknet::{
     core::types::FieldElement,
     providers::jsonrpc::models::{
-        BlockHashAndNumber, ContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
-        MaybePendingTransactionReceipt, StateUpdate, SyncStatusType, Transaction,
+        BlockHashAndNumber, ContractClass, DeployTransactionResult, MaybePendingBlockWithTxHashes,
+        MaybePendingBlockWithTxs, MaybePendingTransactionReceipt, StateUpdate, SyncStatusType,
+        Transaction,
     },
 };
 
@@ -158,5 +159,5 @@ pub trait BeerusApi {
         version: String,
         contract_address_salt: String,
         constructor_calldata: Vec<String>,
-    ) -> Result<DeployTransactionResult>;
+    ) -> Result<DeployTransactionResult, Error>;
 }

--- a/crates/beerus-rpc/src/api.rs
+++ b/crates/beerus-rpc/src/api.rs
@@ -150,4 +150,13 @@ pub trait BeerusApi {
         block_id: String,
         contract_address: String,
     ) -> Result<FieldElement, Error>;
+
+    #[method(name = "starknet_addDeployTransaction")]
+    async fn starknet_add_deploy_transaction(
+        &self,
+        contract_class: String,
+        version: String,
+        contract_address_salt: String,
+        constructor_calldata: Vec<String>,
+    ) -> Result<DeployTransactionResult>;
 }

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -282,11 +282,13 @@ impl BeerusApiServer for BeerusRpc {
             contract_address_salt,
             constructor_calldata,
         };
-        Ok(self
-            ._beerus
+        let result = self
+            .beerus
             .starknet_lightclient
             .add_deploy_transaction(&deploy_transaction)
             .await
-            .map_err(|e| Error::Call(CallError::Failed(anyhow::anyhow!(e.to_string())))))
+            .map_err(|e| Error::Call(CallError::Failed(anyhow::anyhow!(e.to_string()))))?;
+            
+        Ok(result)
     }
 }

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -288,7 +288,7 @@ impl BeerusApiServer for BeerusRpc {
             .add_deploy_transaction(&deploy_transaction)
             .await
             .map_err(|e| Error::Call(CallError::Failed(anyhow::anyhow!(e.to_string()))))?;
-            
+
         Ok(result)
     }
 }

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -12,8 +12,9 @@ use ethers::types::U256;
 use starknet::{
     core::types::FieldElement,
     providers::jsonrpc::models::{
-        BlockHashAndNumber, ContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
-        MaybePendingTransactionReceipt, StateUpdate, SyncStatusType, Transaction,
+        BlockHashAndNumber, BroadcastedDeployTransaction, ContractClass, DeployTransactionResult,
+        MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingTransactionReceipt,
+        StateUpdate, SyncStatusType, Transaction,
     },
 };
 use std::net::SocketAddr;
@@ -257,5 +258,35 @@ impl BeerusApiServer for BeerusRpc {
             .get_class_hash_at(&block_id, contract_address)
             .await
             .unwrap())
+    }
+
+    async fn starknet_add_deploy_transaction(
+        &self,
+        contract_class: String,
+        version: String,
+        contract_address_salt: String,
+        constructor_calldata: Vec<String>,
+    ) -> Result<DeployTransactionResult, Error> {
+        let contract_class_bytes = contract_class.as_bytes();
+        let contract_class = serde_json::from_slice(contract_class_bytes).unwrap();
+        let version: u64 = version.parse().unwrap();
+        let contract_address_salt: FieldElement =
+            FieldElement::from_str(&contract_address_salt).unwrap();
+        let constructor_calldata = constructor_calldata
+            .iter()
+            .map(|x| FieldElement::from_str(x).unwrap())
+            .collect();
+        let deploy_transaction = BroadcastedDeployTransaction {
+            contract_class,
+            version,
+            contract_address_salt,
+            constructor_calldata,
+        };
+        Ok(self
+            ._beerus
+            .starknet_lightclient
+            .add_deploy_transaction(&deploy_transaction)
+            .await
+            .map_err(|e| Error::Call(CallError::Failed(anyhow::anyhow!(e.to_string())))))
     }
 }

--- a/examples/beerus-rpc/starknet_addDeployTransaction.hurl
+++ b/examples/beerus-rpc/starknet_addDeployTransaction.hurl
@@ -1,0 +1,10 @@
+POST http://0.0.0.0:3030
+Content-Type: application/json
+{
+    "jsonrpc":"2.0","method":"starknet_addDeployTransaction","params":[
+        "0x1e2208b571b2cb68908f37a196ed5e391c8933a6db23bb3939acedee40d9b8a",
+        "10",
+        "0x039564c4f6d9f45a963a6dc8cf32737f0d51a08e446304626173fd838bd70e1c",
+        "[0x1234, 0x5678]"
+    ],"id":1
+}


### PR DESCRIPTION
Migrate `add_deploy_transaction` from `beerus-rest-api` to `beerus-rpc`.
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #228 

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `add_deploy_transaction` has been moved to `beerus-rpc`.
- Add rpc example for `add_deploy_transaction`.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
