### PR TITLE
feat: Migrate Starknet : query_pending_transactions

### DIFF
--- a/crates/beerus-core/src/lightclient/beerus.rs
+++ b/crates/beerus-core/src/lightclient/beerus.rs
@@ -774,4 +774,21 @@ impl BeerusLightClient {
 
         Ok(transaction_count)
     }
+
+    ///  Returns the pending transactions in the starknet transaction pool
+    /// See https://github.com/starknet-io/starknet-addresses for the StarkNet core contract address on different networks.
+    /// # Arguments
+    /// # Returns
+    /// `Ok(U256)` if the operation was successful - A vector of pending transactions
+    /// `Err(eyre::Report)` if the operation failed - No pending transactions found.
+    pub async fn starknet_pending_transactions(&self) -> Result<Vec<Transaction>> {
+        let transactions_result = self.starknet_lightclient.pending_transactions().await;
+
+        let transactions = match transactions_result {
+            Ok(transactions) => transactions,
+            Err(err) => return Err(eyre::eyre!("Failed to get pending transactions: {}", err)),
+        };
+
+        Ok(transactions)
+    }
 }

--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -3952,4 +3952,38 @@ mod tests {
         // Assert that the error returned by the `add_declare_transaction` method of the Beerus light client is the expected error.
         assert_eq!(result.unwrap_err().to_string(), expected_error.to_string());
     }
+
+    #[tokio::test]
+    async fn given_error_result_when_calling_starknet_pending_transactions_then_should_return_same_error(
+    ) {
+        // Given
+        // Mock config and beerus light client with a mocked starknet light client.
+        let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
+
+        // The expected error is what is returned from the API Error
+        let expected_error = "Failed to fetch pending transactions";
+
+        // Mock dependencies.
+        starknet_lightclient_mock
+            .expect_pending_transactions()
+            .return_once(move || Err(eyre!(expected_error))); // Return a network error
+
+        let beerus = BeerusLightClient::new(
+            config.clone(),
+            Box::new(ethereum_lightclient_mock),
+            Box::new(starknet_lightclient_mock),
+        );
+
+        // When
+        let result = beerus.starknet_pending_transactions().await;
+
+        // Then
+        // Assert that the `starknet_pending_transactions` method of the Beerus light client returns `Err`.
+        assert!(result.is_err());
+        // Assert that the error returned by the `starknet_pending_transactions` method of the Beerus light client is the expected error.
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Failed to fetch pending transactions".to_string()
+        );
+    }
 }

--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -3961,7 +3961,7 @@ mod tests {
         let (config, ethereum_lightclient_mock, mut starknet_lightclient_mock) = mock_clients();
 
         // The expected error is what is returned from the API Error
-        let expected_error = "Failed to fetch pending transactions";
+        let expected_error = "Network Failure";
 
         // Mock dependencies.
         starknet_lightclient_mock
@@ -3980,10 +3980,15 @@ mod tests {
         // Then
         // Assert that the `starknet_pending_transactions` method of the Beerus light client returns `Err`.
         assert!(result.is_err());
+        // let actual_error = result.unwrap_err().to_string();
+        // println!("expected error: {}", expected_error);
+        // println!("actual error: {}", actual_error);
+        // assert_eq!(actual_error, expected_error);
+
         // Assert that the error returned by the `starknet_pending_transactions` method of the Beerus light client is the expected error.
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Failed to fetch pending transactions".to_string()
+            "Failed to get pending transactions: Network Failure"
         );
     }
 }

--- a/crates/beerus-rpc/src/api.rs
+++ b/crates/beerus-rpc/src/api.rs
@@ -50,6 +50,8 @@ pub enum BeerusApiError {
     TooManyKeysInFilter = 34,
     #[error("Internal server error")]
     InternalServerError = 500,
+    #[error("Failed to fetch pending transactions")]
+    FailedToFetchPendingTransactions = 38,
 }
 
 impl From<BeerusApiError> for Error {
@@ -178,4 +180,7 @@ pub trait BeerusApi {
         continuation_token: Option<String>,
         chunk_size: u64,
     ) -> Result<EventsPage, Error>;
+
+    #[method(name = "starknet_pendingTransactions")]
+    async fn starknet_pending_transactions(&self) -> Result<Vec<Transaction>, Error>;
 }

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -329,4 +329,14 @@ impl BeerusApiServer for BeerusRpc {
             .await
             .unwrap())
     }
+
+    async fn starknet_pending_transactions(&self) -> Result<Vec<Transaction>, Error> {
+        let transactions_result = self
+            .beerus
+            .starknet_lightclient
+            .pending_transactions()
+            .await
+            .map_err(|_| Error::from(BeerusApiError::FailedToFetchPendingTransactions));
+        Ok(transactions_result.unwrap())
+    }
 }


### PR DESCRIPTION
Added query pending transactions to Beerus Lightclient and API

# Pull Request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Light client cannot fetch pending transactions via [starknet_pendingTransactions](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/starkware-libs/starknet-specs/master/api/starknet_api_openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=true&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)
 

Issue Number: #231 

# What is the new behavior?

Pending Transactions can now be queried from starknet_pendingTransactions
tests included

# Does this introduce a breaking change?

- [ ] Yes
- [x] No