### PR TITLE
fix: expand of tilde from env variables value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "shellexpand",
  "starknet",
  "tokio",
  "toml 0.7.3",
@@ -1489,6 +1490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1506,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5218,6 +5239,15 @@ checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
  "digest 0.10.6",
  "keccak",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/crates/beerus-core/Cargo.toml
+++ b/crates/beerus-core/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1.21.2", features = ["macros"] }
 futures = { version = "0.3", default-features = false }
 ethabi = "18.0.0"
 toml = "0.7.3"
+shellexpand = "3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = "0.2.6"

--- a/crates/beerus-core/src/config.rs
+++ b/crates/beerus-core/src/config.rs
@@ -6,7 +6,7 @@ use helios::config::{checkpoints, networks::Network};
 #[cfg(feature = "std")]
 use log::{error, info};
 use serde::Deserialize;
-use shellexpand::tilde;
+use shellexpand;
 #[cfg(feature = "std")]
 use std::{env, fs, net::SocketAddr, path::PathBuf, str::FromStr};
 
@@ -70,7 +70,7 @@ impl Config {
         config.ethereum_execution_rpc = string_env_or_die("ETHEREUM_EXECUTION_RPC_URL");
         config.starknet_rpc = string_env_or_die("STARKNET_RPC_URL");
         if let Ok(dir) = std::env::var("DATA_DIR") {
-            config.data_dir = PathBuf::from(tilde(&dir).to_string());
+            config.data_dir = PathBuf::from(shellexpand::tilde(&dir).to_string());
         }
 
         if let Ok(raw_addr) = std::env::var("BEERUS_RPC_ADDR") {
@@ -217,7 +217,7 @@ impl Default for Config {
             starknet_rpc: "http://localhost:9545".to_string(),
             starknet_core_contract_address: Address::from_str(STARKNET_GOERLI_CC_ADDRESS).unwrap(),
             #[cfg(feature = "std")]
-            data_dir: PathBuf::from(tilde(DEFAULT_DATA_DIR).to_string()),
+            data_dir: PathBuf::from(shellexpand::tilde(DEFAULT_DATA_DIR).to_string()),
             poll_interval_secs: Some(DEFAULT_POLL_INTERVAL_SECS),
             #[cfg(feature = "std")]
             beerus_rpc_address: Some(SocketAddr::from_str(DEFAULT_BEERUS_RPC_ADDR).unwrap()),

--- a/crates/beerus-core/src/config.rs
+++ b/crates/beerus-core/src/config.rs
@@ -6,7 +6,7 @@ use helios::config::{checkpoints, networks::Network};
 #[cfg(feature = "std")]
 use log::{error, info};
 use serde::Deserialize;
-#[cfg(feature = "std")]
+use shellexpand::tilde;
 use std::{env, fs, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use crate::stdlib::string::{String, ToString};
@@ -69,7 +69,7 @@ impl Config {
         config.ethereum_execution_rpc = string_env_or_die("ETHEREUM_EXECUTION_RPC_URL");
         config.starknet_rpc = string_env_or_die("STARKNET_RPC_URL");
         if let Ok(dir) = std::env::var("DATA_DIR") {
-            config.data_dir = PathBuf::from(dir);
+            config.data_dir = PathBuf::from(tilde(&dir).to_string());
         }
 
         if let Ok(raw_addr) = std::env::var("BEERUS_RPC_ADDR") {
@@ -216,7 +216,7 @@ impl Default for Config {
             starknet_rpc: "http://localhost:9545".to_string(),
             starknet_core_contract_address: Address::from_str(STARKNET_GOERLI_CC_ADDRESS).unwrap(),
             #[cfg(feature = "std")]
-            data_dir: PathBuf::from(DEFAULT_DATA_DIR),
+            data_dir: PathBuf::from(tilde(DEFAULT_DATA_DIR).to_string()),
             poll_interval_secs: Some(DEFAULT_POLL_INTERVAL_SECS),
             #[cfg(feature = "std")]
             beerus_rpc_address: Some(SocketAddr::from_str(DEFAULT_BEERUS_RPC_ADDR).unwrap()),

--- a/crates/beerus-core/src/config.rs
+++ b/crates/beerus-core/src/config.rs
@@ -7,6 +7,7 @@ use helios::config::{checkpoints, networks::Network};
 use log::{error, info};
 use serde::Deserialize;
 use shellexpand::tilde;
+#[cfg(feature = "std")]
 use std::{env, fs, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use crate::stdlib::string::{String, ToString};

--- a/crates/beerus-core/tests/config.rs
+++ b/crates/beerus-core/tests/config.rs
@@ -8,7 +8,7 @@ mod tests {
     };
     use ethers::types::Address;
     use serial_test::serial;
-    use shellexpand::tilde;
+    use shellexpand;
     use std::env;
     use std::{path::PathBuf, str::FromStr};
 
@@ -72,7 +72,7 @@ mod tests {
 
         assert_eq!(
             conf.data_dir,
-            PathBuf::from(tilde(DEFAULT_DATA_DIR).to_string())
+            PathBuf::from(shellexpand::tilde(DEFAULT_DATA_DIR).to_string())
         );
 
         assert_eq!(conf.poll_interval_secs, Some(DEFAULT_POLL_INTERVAL_SECS));

--- a/crates/beerus-core/tests/config.rs
+++ b/crates/beerus-core/tests/config.rs
@@ -8,6 +8,7 @@ mod tests {
     };
     use ethers::types::Address;
     use serial_test::serial;
+    use shellexpand::tilde;
     use std::env;
     use std::{path::PathBuf, str::FromStr};
 
@@ -68,7 +69,12 @@ mod tests {
             conf.starknet_core_contract_address,
             Address::from_str(STARKNET_GOERLI_CC_ADDRESS).unwrap()
         );
-        assert_eq!(conf.data_dir, PathBuf::from(DEFAULT_DATA_DIR));
+
+        assert_eq!(
+            conf.data_dir,
+            PathBuf::from(tilde(DEFAULT_DATA_DIR).to_string())
+        );
+
         assert_eq!(conf.poll_interval_secs, Some(DEFAULT_POLL_INTERVAL_SECS));
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Tilde in environment variables are not expanded. For this reason, the default data dir `~/.beerus/tmp`
is created in the directory from where the command is executed.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #394 

# What is the new behavior?

The tilde is correctly expanded to fit the expected path.
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
