### PR TITLE
fix: change helios revision with a version that compiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "client"
 version = "0.4.0"
-source = "git+https://github.com/a16z/helios?rev=f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98#f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98"
+source = "git+https://github.com/glihm/helios?rev=688ed805a142ef6ead361889cc6d42a4cdede918#688ed805a142ef6ead361889cc6d42a4cdede918"
 dependencies = [
  "common",
  "config",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.4.0"
-source = "git+https://github.com/a16z/helios?rev=f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98#f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98"
+source = "git+https://github.com/glihm/helios?rev=688ed805a142ef6ead361889cc6d42a4cdede918#688ed805a142ef6ead361889cc6d42a4cdede918"
 dependencies = [
  "ethers",
  "eyre",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.4.0"
-source = "git+https://github.com/a16z/helios?rev=f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98#f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98"
+source = "git+https://github.com/glihm/helios?rev=688ed805a142ef6ead361889cc6d42a4cdede918#688ed805a142ef6ead361889cc6d42a4cdede918"
 dependencies = [
  "common",
  "ethers",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "consensus"
 version = "0.4.0"
-source = "git+https://github.com/a16z/helios?rev=f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98#f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98"
+source = "git+https://github.com/glihm/helios?rev=688ed805a142ef6ead361889cc6d42a4cdede918#688ed805a142ef6ead361889cc6d42a4cdede918"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2061,7 +2061,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "execution"
 version = "0.4.0"
-source = "git+https://github.com/a16z/helios?rev=f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98#f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98"
+source = "git+https://github.com/glihm/helios?rev=688ed805a142ef6ead361889cc6d42a4cdede918#688ed805a142ef6ead361889cc6d42a4cdede918"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2570,7 +2570,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 [[package]]
 name = "helios"
 version = "0.4.0"
-source = "git+https://github.com/a16z/helios?rev=f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98#f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98"
+source = "git+https://github.com/glihm/helios?rev=688ed805a142ef6ead361889cc6d42a4cdede918#688ed805a142ef6ead361889cc6d42a4cdede918"
 dependencies = [
  "client",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 beerus-core = { path = "./crates/beerus-core" }
 
 # Helios revision is supposed to be changed by the corresponding tag once the revision is released. Next expected tag: 0.5.0.
-helios = { git = "https://github.com/a16z/helios", rev = "f63e4142c8c8094cdf94cf8d1ef1cb637a7eac98" }
+helios = { git = "https://github.com/glihm/helios", rev = "688ed805a142ef6ead361889cc6d42a4cdede918" }
 
 #TODO: update with version tag instead of hash rev when available
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "e72cc0a4b3ea67c7691ebec58300da3c21f0abb2" }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

CI is broken by helios dependency. This PR changes the revision of helios to have a version that
compiles fine in wasm32 and allows us to pass all tests in the CI for wasm32.

Howerver, it's important to note that some work still pending on helios for wasm32 target.
But at least, beerus is working fine in wasm32, only call to `eth_call` will fail in wasm32.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #383

# What is the new behavior?

Now wasm32 target compiles fine.
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
