### PR TITLE
testing: ensure tests that modify env variable are run in serial

### DIFF
--- a/crates/beerus-core/tests/config.rs
+++ b/crates/beerus-core/tests/config.rs
@@ -74,6 +74,7 @@ mod tests {
 
     /// Test `from_env` function.
     #[test]
+    #[serial]
     fn all_envs_set_returns_config() {
         Config::clean_env();
         env::set_var("ETHEREUM_NETWORK", "mainnet");


### PR DESCRIPTION
Tests are running in parallel by default, and we use 2 threads. Several tests are manipulating environment variables, which may cause conflicts if at least to of them run at the same time.

<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [X] Testing
- [ ] Other (please describe):

# What is the current behavior?

Sometimes tests are not passing in configuration, but we are not sure why.
Something we saw is that running the tests several time has different behavior (one time they fail,
other time they pass).
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Adding the serial macro to a test that is modifying environment variable helps stabilizing
the runs. I have tested to run the tests with 2 / 4 / 8 / 10 threads, I can't make it fail
now.
# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
