### PR TITLE
fix malformatted number to fit eth hex format (#422)

### DIFF
--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -70,7 +70,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u256_to_hex_string(balance))
+        Ok(hex_string!(balance))
     }
 
     async fn eth_get_transaction_count(
@@ -90,7 +90,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u64_to_hex_string(tx_count))
+        Ok(hex_string!(tx_count))
     }
 
     async fn eth_get_block_transaction_count_by_hash(&self, hash: &str) -> Result<String, Error> {
@@ -105,7 +105,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u64_to_hex_string(tx_count))
+        Ok(hex_string!(tx_count))
     }
 
     async fn eth_get_block_transaction_count_by_number(
@@ -121,7 +121,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u64_to_hex_string(tx_count))
+        Ok(hex_string!(tx_count))
     }
 
     async fn eth_get_code(&self, address: &str, block: BlockTag) -> Result<String, Error> {
@@ -160,7 +160,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u64_to_hex_string(gas_estimation))
+        Ok(hex_string!(gas_estimation))
     }
 
     async fn eth_chain_id(&self) -> Result<String, Error> {
@@ -173,7 +173,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u64_to_hex_string(chain_id))
+        Ok(hex_string!(chain_id))
     }
 
     async fn eth_gas_price(&self) -> Result<String, Error> {
@@ -186,7 +186,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u256_to_hex_string(gas_price))
+        Ok(hex_string!(gas_price))
     }
 
     async fn eth_max_priority_fee_per_gas(&self) -> Result<String, Error> {
@@ -199,7 +199,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u256_to_hex_string(max_priority_fee_per_gas))
+        Ok(hex_string!(max_priority_fee_per_gas))
     }
 
     async fn eth_block_number(&self) -> Result<String, Error> {
@@ -212,7 +212,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(utils::u64_to_hex_string(block_number))
+        Ok(hex_string!(block_number))
     }
 
     async fn eth_get_block_by_number(

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod utils;
 
 use crate::api::{BeerusApiError, BeerusRpcServer};
 use beerus_core::{
@@ -69,7 +70,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{balance:x}"))
+        Ok(utils::u256_to_hex_string(balance))
     }
 
     async fn eth_get_transaction_count(
@@ -89,7 +90,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{tx_count:x}"))
+        Ok(utils::u64_to_hex_string(tx_count))
     }
 
     async fn eth_get_block_transaction_count_by_hash(&self, hash: &str) -> Result<String, Error> {
@@ -104,7 +105,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{tx_count:x}"))
+        Ok(utils::u64_to_hex_string(tx_count))
     }
 
     async fn eth_get_block_transaction_count_by_number(
@@ -120,7 +121,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{tx_count:x}"))
+        Ok(utils::u64_to_hex_string(tx_count))
     }
 
     async fn eth_get_code(&self, address: &str, block: BlockTag) -> Result<String, Error> {
@@ -159,7 +160,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{gas_estimation:x}"))
+        Ok(utils::u64_to_hex_string(gas_estimation))
     }
 
     async fn eth_chain_id(&self) -> Result<String, Error> {
@@ -172,7 +173,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{chain_id:x}"))
+        Ok(utils::u64_to_hex_string(chain_id))
     }
 
     async fn eth_gas_price(&self) -> Result<String, Error> {
@@ -184,7 +185,8 @@ impl BeerusRpcServer for BeerusRpc {
             .get_gas_price()
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(format!("0x{gas_price:x}"))
+
+        Ok(utils::u256_to_hex_string(gas_price))
     }
 
     async fn eth_max_priority_fee_per_gas(&self) -> Result<String, Error> {
@@ -197,7 +199,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(format!("0x{max_priority_fee_per_gas:x}"))
+        Ok(utils::u256_to_hex_string(max_priority_fee_per_gas))
     }
 
     async fn eth_block_number(&self) -> Result<String, Error> {
@@ -209,7 +211,8 @@ impl BeerusRpcServer for BeerusRpc {
             .get_block_number()
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(format!("0x{block_number:x}"))
+
+        Ok(utils::u64_to_hex_string(block_number))
     }
 
     async fn eth_get_block_by_number(
@@ -253,6 +256,7 @@ impl BeerusRpcServer for BeerusRpc {
             .send_raw_transaction(&bytes)
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
+
         Ok(raw_tx.to_string())
     }
 

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -69,7 +69,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(balance.to_string())
+        Ok(format!("0x{balance:x}"))
     }
 
     async fn eth_get_transaction_count(
@@ -79,7 +79,8 @@ impl BeerusRpcServer for BeerusRpc {
     ) -> Result<String, Error> {
         let address =
             parse_eth_address(address).map_err(|_| Error::from(BeerusApiError::InvalidCallData))?;
-        let nonce = self
+
+        let tx_count = self
             .beerus
             .ethereum_lightclient
             .read()
@@ -87,7 +88,8 @@ impl BeerusRpcServer for BeerusRpc {
             .get_transaction_count(&address, block)
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(nonce.to_string())
+
+        Ok(format!("0x{tx_count:x}"))
     }
 
     async fn eth_get_block_transaction_count_by_hash(&self, hash: &str) -> Result<String, Error> {
@@ -102,7 +104,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(tx_count.to_string())
+        Ok(format!("0x{tx_count:x}"))
     }
 
     async fn eth_get_block_transaction_count_by_number(
@@ -117,7 +119,8 @@ impl BeerusRpcServer for BeerusRpc {
             .get_block_transaction_count_by_number(block)
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(tx_count.to_string())
+
+        Ok(format!("0x{tx_count:x}"))
     }
 
     async fn eth_get_code(&self, address: &str, block: BlockTag) -> Result<String, Error> {
@@ -156,7 +159,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(gas_estimation.to_string())
+        Ok(format!("0x{gas_estimation:x}"))
     }
 
     async fn eth_chain_id(&self) -> Result<String, Error> {
@@ -169,7 +172,7 @@ impl BeerusRpcServer for BeerusRpc {
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
 
-        Ok(chain_id.to_string())
+        Ok(format!("0x{chain_id:x}"))
     }
 
     async fn eth_gas_price(&self) -> Result<String, Error> {
@@ -181,7 +184,7 @@ impl BeerusRpcServer for BeerusRpc {
             .get_gas_price()
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(gas_price.to_string())
+        Ok(format!("0x{gas_price:x}"))
     }
 
     async fn eth_max_priority_fee_per_gas(&self) -> Result<String, Error> {
@@ -193,7 +196,8 @@ impl BeerusRpcServer for BeerusRpc {
             .get_priority_fee()
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(max_priority_fee_per_gas.to_string())
+
+        Ok(format!("0x{max_priority_fee_per_gas:x}"))
     }
 
     async fn eth_block_number(&self) -> Result<String, Error> {
@@ -205,7 +209,7 @@ impl BeerusRpcServer for BeerusRpc {
             .get_block_number()
             .await
             .map_err(|_| Error::from(BeerusApiError::ContractError))?;
-        Ok(block_number.to_string())
+        Ok(format!("0x{block_number:x}"))
     }
 
     async fn eth_get_block_by_number(

--- a/crates/beerus-rpc/src/utils.rs
+++ b/crates/beerus-rpc/src/utils.rs
@@ -1,11 +1,8 @@
-use ethers::types::U256;
-
-/// Converts a u64 integer to it's hexadecimal string.
-pub fn u64_to_hex_string(val: u64) -> String {
-    format!("0x{val:x}")
-}
-
-/// Converts a u256 integer to it's hexadecimal string.
-pub fn u256_to_hex_string(val: U256) -> String {
-    format!("0x{val:x}")
+/// Prints hex string of the given value.
+/// Works only if the argument implements LowerHex trait.
+#[macro_export]
+macro_rules! hex_string {
+    ($e:expr) => {
+        format!("0x{:x}", $e)
+    };
 }

--- a/crates/beerus-rpc/src/utils.rs
+++ b/crates/beerus-rpc/src/utils.rs
@@ -1,0 +1,11 @@
+use ethers::types::U256;
+
+/// Converts a u64 integer to it's hexadecimal string.
+pub fn u64_to_hex_string(val: u64) -> String {
+    format!("0x{val:x}")
+}
+
+/// Converts a u256 integer to it's hexadecimal string.
+pub fn u256_to_hex_string(val: U256) -> String {
+    format!("0x{val:x}")
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

`eth_` endpoints returning numbers are displayed in decimal. 

Issue Number: #422 

# What is the new behavior?

`eth_` endpoints returning numbers are now displayed as hexadecimal string.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No


# Other information

This PR is not conflicted with #416 and can be merged to achieve some issues listed in #422.
