### PR TITLE
fix: remove helios rpc server

### DIFF
--- a/crates/beerus-core/src/lightclient/ethereum/helios_lightclient.rs
+++ b/crates/beerus-core/src/lightclient/ethereum/helios_lightclient.rs
@@ -258,31 +258,6 @@ impl HeliosLightClient {
         })
     }
 
-    #[cfg(feature = "std")]
-    pub async fn new_rpc(config: Config) -> eyre::Result<Self> {
-        // Build the Helios wrapped light client.
-        let mut builder = ClientBuilder::new()
-            .network(config.ethereum_network()?)
-            .consensus_rpc(config.ethereum_consensus_rpc.as_str())
-            .execution_rpc(config.ethereum_execution_rpc.as_str())
-            .load_external_fallback()
-            .data_dir(config.data_dir.clone())
-            .rpc_port(config.helios_rpc_address.unwrap());
-
-        builder = HeliosLightClient::load_checkpoint(
-            builder,
-            config.ethereum_checkpoint,
-            config.data_dir.clone(),
-        );
-
-        let helios_light_client: Client<FileDB> = builder.build()?;
-
-        Ok(Self {
-            helios_light_client,
-            starknet_core_contract_address: config.starknet_core_contract_address,
-        })
-    }
-
     /// Loads helios checkpoint -if any- from the configuration DATA_DIR.
     ///
     /// Helios by default uses the file for the checkpoint if None is passed

--- a/crates/beerus-rpc/src/main.rs
+++ b/crates/beerus-rpc/src/main.rs
@@ -17,7 +17,7 @@ async fn main() {
     let config = Config::from_env();
 
     info!("creating Ethereum(Helios) lightclient...");
-    let ethereum_lightclient = match HeliosLightClient::new_rpc(config.clone()).await {
+    let ethereum_lightclient = match HeliosLightClient::new(config.clone()).await {
         Ok(ethereum_lightclient) => ethereum_lightclient,
         Err(err) => {
             error! {"{}", err};


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [X] Other (please describe):

Removing existing feature: helios rpc server.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# What is the new behavior?

As discussed during the CC, as we are not doing
a proxy to helios, we then avoid having two
ports open at the same time when it's no longer required.

Helios RPC is no longer started, and only one port is used, the beerus port.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [X] Yes (if having a port closed if considered as a breaking change)
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

This will help the CI and dockerization PR #385. 