### PR TITLE
fix: Beerus stops processing incoming connections on hosts with less than 3 cpu

### DIFF
--- a/crates/beerus-core/src/lightclient/beerus.rs
+++ b/crates/beerus-core/src/lightclient/beerus.rs
@@ -6,7 +6,7 @@ use gloo_timers::callback::Interval;
 #[cfg(not(feature = "std"))]
 use wasm_bindgen_futures::spawn_local;
 
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 #[cfg(not(feature = "std"))]
 use core::str::FromStr;
@@ -71,7 +71,7 @@ pub struct BeerusLightClient {
     /// Global configuration.
     pub config: Config,
     /// Ethereum light client.
-    pub ethereum_lightclient: Arc<RwLock<Box<dyn EthereumLightClient>>>,
+    pub ethereum_lightclient: Arc<Mutex<Box<dyn EthereumLightClient>>>,
     /// StarkNet light client.
     pub starknet_lightclient: Arc<Box<dyn StarkNetLightClient>>,
     /// Sync status.
@@ -93,7 +93,7 @@ impl BeerusLightClient {
         starknet_lightclient_raw: Box<dyn StarkNetLightClient>,
     ) -> Self {
         // Create a new Ethereum light client.
-        let ethereum_lightclient = Arc::new(RwLock::with_max_readers(ethereum_lightclient_raw, 1));
+        let ethereum_lightclient = Arc::new(Mutex::new(ethereum_lightclient_raw));
         // Create a new StarkNet light client.
         let starknet_lightclient = Arc::new(starknet_lightclient_raw);
         let starknet_core_abi = include_str!("../resources/starknet_core_abi.json");
@@ -121,7 +121,7 @@ impl BeerusLightClient {
     pub async fn start(&mut self) -> Result<()> {
         if let SyncStatus::NotSynced = self.sync_status {
             // Start the Ethereum light client.
-            self.ethereum_lightclient.write().await.start().await?;
+            self.ethereum_lightclient.lock().await.start().await?;
             // Start the StarkNet light client.
             self.starknet_lightclient.start().await?;
             self.sync_status = SyncStatus::Synced;
@@ -135,14 +135,14 @@ impl BeerusLightClient {
             let task = async move {
                 loop {
                     let state_root = ethereum_clone
-                        .read()
+                        .lock()
                         .await
                         .starknet_state_root()
                         .await
                         .unwrap();
 
                     let last_proven_block = ethereum_clone
-                        .read()
+                        .lock()
                         .await
                         .starknet_last_proven_block()
                         .await
@@ -301,7 +301,7 @@ impl BeerusLightClient {
     ) -> Result<FieldElement> {
         let last_block = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_last_proven_block()
             .await?
@@ -338,7 +338,7 @@ impl BeerusLightClient {
 
         let last_block = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_last_proven_block()
             .await?
@@ -384,7 +384,7 @@ impl BeerusLightClient {
     pub async fn starknet_get_nonce(&self, address: FieldElement) -> Result<FieldElement> {
         let last_block = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_last_proven_block()
             .await?
@@ -428,7 +428,7 @@ impl BeerusLightClient {
         // Call the StarkNet core contract.
         let call_response = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .call(&call_opts, BlockTag::Latest)
             .await?;
@@ -468,7 +468,7 @@ impl BeerusLightClient {
         // Call the StarkNet core contract.
         let call_response = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .call(&call_opts, BlockTag::Latest)
             .await?;
@@ -508,7 +508,7 @@ impl BeerusLightClient {
         // Call the StarkNet core contract.
         let call_response = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .call(&call_opts, BlockTag::Latest)
             .await?;
@@ -543,7 +543,7 @@ impl BeerusLightClient {
         // Call the StarkNet core contract.
         let call_response = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .call(&call_opts, BlockTag::Latest)
             .await?;
@@ -611,7 +611,7 @@ impl BeerusLightClient {
         let cloned_node = self.node.read().await;
         let state_root = self
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_state_root()
             .await?

--- a/crates/beerus-core/src/lightclient/beerus.rs
+++ b/crates/beerus-core/src/lightclient/beerus.rs
@@ -93,7 +93,7 @@ impl BeerusLightClient {
         starknet_lightclient_raw: Box<dyn StarkNetLightClient>,
     ) -> Self {
         // Create a new Ethereum light client.
-        let ethereum_lightclient = Arc::new(RwLock::new(ethereum_lightclient_raw));
+        let ethereum_lightclient = Arc::new(RwLock::with_max_readers(ethereum_lightclient_raw, 1));
         // Create a new StarkNet light client.
         let starknet_lightclient = Arc::new(starknet_lightclient_raw);
         let starknet_core_abi = include_str!("../resources/starknet_core_abi.json");

--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -161,7 +161,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .send_raw_transaction(bytes)
             .await
@@ -202,7 +202,7 @@ mod tests {
         // Send raw transaction.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .send_raw_transaction(bytes)
             .await;
@@ -245,7 +245,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_balance(&addr, block)
             .await
@@ -289,7 +289,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_balance(&addr, block)
             .await;
@@ -332,7 +332,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_nonce(&addr, block)
             .await
@@ -376,7 +376,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_nonce(&addr, block)
             .await;
@@ -413,7 +413,7 @@ mod tests {
 
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_number()
             .await;
@@ -450,7 +450,7 @@ mod tests {
 
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_chain_id()
             .await
@@ -488,7 +488,7 @@ mod tests {
         // When
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_code(&addr, block)
             .await;
@@ -534,7 +534,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_code(&addr, block)
             .await;
@@ -572,7 +572,7 @@ mod tests {
         // When
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_count(&address, block)
             .await;
@@ -616,7 +616,7 @@ mod tests {
         // Query the transaction of the Ethereum address from a given block.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_count(&address, block)
             .await;
@@ -653,7 +653,7 @@ mod tests {
         // When
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_transaction_count_by_number(block)
             .await;
@@ -696,7 +696,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_transaction_count_by_number(block)
             .await;
@@ -757,7 +757,7 @@ mod tests {
 
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_by_number(BlockTag::Number(expected_block_number), false)
             .await;
@@ -797,7 +797,7 @@ mod tests {
 
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_by_number(BlockTag::Latest, false)
             .await;
@@ -834,7 +834,7 @@ mod tests {
         // When
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_transaction_count_by_hash(&hash)
             .await;
@@ -877,7 +877,7 @@ mod tests {
         // Query the balance of the Ethereum address.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_transaction_count_by_hash(&hash)
             .await;
@@ -922,7 +922,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_by_hash(&tx_hash)
             .await;
@@ -967,7 +967,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_by_hash(&tx_hash)
             .await;
@@ -1008,7 +1008,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_gas_price()
             .await;
@@ -1050,7 +1050,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_gas_price()
             .await;
@@ -1097,7 +1097,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .estimate_gas(&call_opts)
             .await;
@@ -1143,7 +1143,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .estimate_gas(&call_opts)
             .await;
@@ -1205,7 +1205,7 @@ mod tests {
 
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_by_hash(hash.as_ref(), false)
             .await;
@@ -1247,7 +1247,7 @@ mod tests {
 
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_by_hash(hash.as_ref(), false)
             .await;
@@ -1288,7 +1288,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_priority_fee()
             .await;
@@ -1330,7 +1330,7 @@ mod tests {
         // Query the transaction data given a hash on Ethereum.
         let result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_priority_fee()
             .await;
@@ -1415,7 +1415,7 @@ mod tests {
         // Perform the test call.
         let starknet_state_root = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_state_root()
             .await
@@ -1448,7 +1448,7 @@ mod tests {
         // Perform the test call.
         let starknet_state_root_result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_state_root()
             .await;
@@ -1489,7 +1489,7 @@ mod tests {
         // Perform the test call.
         let starknet_block_number = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_last_proven_block()
             .await
@@ -1523,7 +1523,7 @@ mod tests {
         // Perform the test call.
         let starknet_state_root_result = beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .starknet_state_root()
             .await;
@@ -2565,7 +2565,7 @@ mod tests {
     //     // Query the transaction data given a hash on Ethereum.
     //     let result = beerus
     //         .ethereum_lightclient
-    //         .read()
+    //         .lock()
     //         .await
     //         .get_logs(
     //             &Some("finalized".to_string()),
@@ -2610,7 +2610,7 @@ mod tests {
     //     // Query the transaction data given a hash on Ethereum.
     //     let result = beerus
     //         .ethereum_lightclient
-    //         .read()
+    //         .lock()
     //         .await
     //         .get_logs(&None, &None, &None, &None, &None)
     //         .await;

--- a/crates/beerus-rpc/src/lib.rs
+++ b/crates/beerus-rpc/src/lib.rs
@@ -64,7 +64,7 @@ impl BeerusRpcServer for BeerusRpc {
         let balance = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_balance(&address, block)
             .await
@@ -84,7 +84,7 @@ impl BeerusRpcServer for BeerusRpc {
         let tx_count = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_count(&address, block)
             .await
@@ -99,7 +99,7 @@ impl BeerusRpcServer for BeerusRpc {
         let tx_count = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_transaction_count_by_hash(&hash)
             .await
@@ -115,7 +115,7 @@ impl BeerusRpcServer for BeerusRpc {
         let tx_count = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_transaction_count_by_number(block)
             .await
@@ -130,7 +130,7 @@ impl BeerusRpcServer for BeerusRpc {
         let code = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_code(&address, block)
             .await
@@ -142,7 +142,7 @@ impl BeerusRpcServer for BeerusRpc {
         let res = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .call(&opts, block)
             .await
@@ -154,7 +154,7 @@ impl BeerusRpcServer for BeerusRpc {
         let gas_estimation = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .estimate_gas(&opts)
             .await
@@ -167,7 +167,7 @@ impl BeerusRpcServer for BeerusRpc {
         let chain_id = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_chain_id()
             .await
@@ -180,7 +180,7 @@ impl BeerusRpcServer for BeerusRpc {
         let gas_price = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_gas_price()
             .await
@@ -193,7 +193,7 @@ impl BeerusRpcServer for BeerusRpc {
         let max_priority_fee_per_gas = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_priority_fee()
             .await
@@ -206,7 +206,7 @@ impl BeerusRpcServer for BeerusRpc {
         let block_number = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_number()
             .await
@@ -222,7 +222,7 @@ impl BeerusRpcServer for BeerusRpc {
     ) -> Result<Option<ExecutionBlock>, Error> {
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_by_number(block, full_tx)
             .await
@@ -238,7 +238,7 @@ impl BeerusRpcServer for BeerusRpc {
             parse_eth_hash(hash).map_err(|_| Error::from(BeerusApiError::InvalidCallData))?;
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_block_by_hash(&hash, full_tx)
             .await
@@ -251,7 +251,7 @@ impl BeerusRpcServer for BeerusRpc {
         let raw_tx = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .send_raw_transaction(&bytes)
             .await
@@ -268,7 +268,7 @@ impl BeerusRpcServer for BeerusRpc {
             H256::from_str(tx_hash).map_err(|_| Error::from(BeerusApiError::InvalidCallData))?;
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_receipt(&tx_hash)
             .await
@@ -283,7 +283,7 @@ impl BeerusRpcServer for BeerusRpc {
             H256::from_str(hash).map_err(|_| Error::from(BeerusApiError::InvalidCallData))?;
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_by_hash(&tx_hash)
             .await
@@ -299,7 +299,7 @@ impl BeerusRpcServer for BeerusRpc {
             parse_eth_hash(hash).map_err(|_| Error::from(BeerusApiError::InvalidCallData))?;
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_transaction_by_block_hash_and_index(&block_hash, index)
             .await
@@ -309,7 +309,7 @@ impl BeerusRpcServer for BeerusRpc {
     async fn eth_coinbase(&self) -> Result<Address, Error> {
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .coinbase()
             .await
@@ -319,7 +319,7 @@ impl BeerusRpcServer for BeerusRpc {
     async fn eth_syncing(&self) -> Result<SyncingStatus, Error> {
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .syncing()
             .await
@@ -329,7 +329,7 @@ impl BeerusRpcServer for BeerusRpc {
     async fn eth_get_logs(&self, filter: Filter) -> Result<Vec<Log>, Error> {
         self.beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_logs(&filter)
             .await
@@ -347,7 +347,7 @@ impl BeerusRpcServer for BeerusRpc {
         let storage = self
             .beerus
             .ethereum_lightclient
-            .read()
+            .lock()
             .await
             .get_storage_at(&address, slot, block)
             .await


### PR DESCRIPTION
bug: Beerus stops processing incoming connections on hosts with less than 3 cpu

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Beerus stops processing incoming connections on hosts with less than 3 cpu. Readers are created that starve the thread.

Issue Number: #438 

# What is the new behavior?

readers are capped to prevent deadlock when running on env with 2 cpu

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

