### PR TITLE
Matching latest latest release naming

### DIFF
--- a/beerusup
+++ b/beerusup
@@ -64,7 +64,7 @@ install_beerus() {
     ARCHITECTURE="$(uname -m)"
 
     echo "Pulling $NAME release..."
-    PLATFORM_RELEASE="${NAME}_${PLATFORM}_${ARCHITECTURE}"
+    PLATFORM_RELEASE="${NAME}-${PLATFORM}-${ARCHITECTURE}"
     TARBALL_URL="https://github.com/$PROJECT_REPO/releases/download/${LATEST_VER}/${PLATFORM_RELEASE}.tar.gz"
     
     find $PROJECT_BIN ! -name "$INSTALLER" -type f -exec rm {} +


### PR DESCRIPTION
Naming with latest release and script was not matching.

<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Beerusup script was not working: 
![image](https://github.com/keep-starknet-strange/beerus/assets/1952687/ada3ce8e-2750-4d86-b9ec-42b146b424dd)

Issue Number: N/A

# What is the new behavior?
Beerusup script is working as expected:
![image](https://github.com/keep-starknet-strange/beerus/assets/1952687/ab564eaf-8ae7-4737-9229-f537a4a23563)

<!-- Please describe the behavior or changes that are being added by this PR. -->
I made some naming fix in order to match naming with latest release.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
