### PR TITLE
Refactor: Init Beerus from config only

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,29 +241,18 @@ BEERUS_CONFIG=path/to/config.toml cargo run -p beerus-core --example basic
 Beerus can be imported into any Rust project.
 
 ```rust
+use beerus_core::{config::Config, lightclient::beerus::BeerusLightClient};
 use env_logger::Env;
 use eyre::Result;
-use beerus_core::{
-  config::Config,
-  lightclient::{
-    beerus::BeerusLightClient, ethereum::helios_lightclient::HeliosLightClient,
-    starknet::StarkNetLightClientImpl,
-  },
-};
 
 #[tokio::main]
 async fn main() -> Result<()> {
   env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
   let config = Config::from_env();
 
-  let ethereum_lightclient = HeliosLightClient::new(config.clone()).await?;
-  let starknet_lightclient = StarkNetLightClientImpl::new(&config)?;
-  let mut beerus = BeerusLightClient::new(
-    config.clone(),
-    Box::new(ethereum_lightclient),
-    Box::new(starknet_lightclient),
-  );
+  let mut beerus = BeerusLightClient::new(config.clone()).await?;
   beerus.start().await?;
+
   let current_starknet_block = beerus.starknet_lightclient.block_number().await?;
   println!("{:?}", current_starknet_block);
 

--- a/crates/beerus-core/examples/basic.rs
+++ b/crates/beerus-core/examples/basic.rs
@@ -1,10 +1,4 @@
-use beerus_core::{
-    config::Config,
-    lightclient::{
-        beerus::BeerusLightClient, ethereum::helios_lightclient::HeliosLightClient,
-        starknet::StarkNetLightClientImpl,
-    },
-};
+use beerus_core::{config::Config, lightclient::beerus::BeerusLightClient};
 use env_logger::Env;
 use eyre::Result;
 
@@ -13,13 +7,7 @@ async fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     let config = Config::from_env();
 
-    let ethereum_lightclient = HeliosLightClient::new(config.clone()).await?;
-    let starknet_lightclient = StarkNetLightClientImpl::new(&config)?;
-    let mut beerus = BeerusLightClient::new(
-        config.clone(),
-        Box::new(ethereum_lightclient),
-        Box::new(starknet_lightclient),
-    );
+    let mut beerus = BeerusLightClient::new(config.clone()).await?;
     beerus.start().await?;
 
     let current_starknet_block = beerus.starknet_lightclient.block_number().await?;

--- a/crates/beerus-core/examples/call.rs
+++ b/crates/beerus-core/examples/call.rs
@@ -1,10 +1,4 @@
-use beerus_core::{
-    config::Config,
-    lightclient::{
-        beerus::BeerusLightClient, ethereum::helios_lightclient::HeliosLightClient,
-        starknet::StarkNetLightClientImpl,
-    },
-};
+use beerus_core::{config::Config, lightclient::beerus::BeerusLightClient};
 use env_logger::Env;
 use eyre::Result;
 use starknet::{
@@ -18,13 +12,7 @@ async fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     let config = Config::from_env();
-    let ethereum_lightclient = HeliosLightClient::new(config.clone()).await?;
-    let starknet_lightclient = StarkNetLightClientImpl::new(&config)?;
-    let mut beerus = BeerusLightClient::new(
-        config.clone(),
-        Box::new(ethereum_lightclient),
-        Box::new(starknet_lightclient),
-    );
+    let mut beerus = BeerusLightClient::new(config.clone()).await?;
     beerus.start().await?;
 
     let starkgate_addr = "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";

--- a/crates/beerus-core/examples/client.rs
+++ b/crates/beerus-core/examples/client.rs
@@ -1,10 +1,4 @@
-use beerus_core::{
-    config::Config,
-    lightclient::{
-        beerus::BeerusLightClient, ethereum::helios_lightclient::HeliosLightClient,
-        starknet::StarkNetLightClientImpl,
-    },
-};
+use beerus_core::{config::Config, lightclient::beerus::BeerusLightClient};
 use env_logger::Env;
 use eyre::Result;
 use std::env;
@@ -44,13 +38,7 @@ async fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     let config = Config::from_env();
 
-    let ethereum_lightclient = HeliosLightClient::new(config.clone()).await?;
-    let starknet_lightclient = StarkNetLightClientImpl::new(&config)?;
-    let _beerus = BeerusLightClient::new(
-        config.clone(),
-        Box::new(ethereum_lightclient),
-        Box::new(starknet_lightclient),
-    );
+    let _beerus = BeerusLightClient::new(config.clone()).await?;
     println!("Constructed Beerus client!");
     Ok(())
 }

--- a/crates/beerus-core/src/lightclient/beerus.rs
+++ b/crates/beerus-core/src/lightclient/beerus.rs
@@ -93,7 +93,7 @@ pub struct BeerusLightClient {
 
 impl BeerusLightClient {
     /// Create a new Beerus Light Client service.
-    pub async fn new(config: Config) -> Result<Self> {
+    pub async fn new(config: Config) -> EyreResult<Self> {
         info!("creating Ethereum(Helios) lightclient...");
         let ethereum_lightclient_raw = HeliosLightClient::new(config.clone()).await?;
 

--- a/crates/beerus-core/src/lightclient/beerus.rs
+++ b/crates/beerus-core/src/lightclient/beerus.rs
@@ -17,7 +17,13 @@ use crate::stdlib::vec::Vec;
 use crate::stdlib::{collections::BTreeMap, sync::Arc};
 
 use super::{ethereum::EthereumLightClient, starknet::StarkNetLightClient};
-use crate::{config::Config, ethers_helper};
+use crate::{
+    config::Config,
+    ethers_helper,
+    lightclient::{
+        ethereum::helios_lightclient::HeliosLightClient, starknet::StarkNetLightClientImpl,
+    },
+};
 use ethabi::Uint as U256;
 use ethers::{abi::Abi, types::H160};
 use eyre::Result as EyreResult;
@@ -87,11 +93,28 @@ pub struct BeerusLightClient {
 
 impl BeerusLightClient {
     /// Create a new Beerus Light Client service.
-    pub fn new(
+    pub async fn new(config: Config) -> Result<Self> {
+        info!("creating Ethereum(Helios) lightclient...");
+        let ethereum_lightclient_raw = HeliosLightClient::new(config.clone()).await?;
+
+        info!("creating Starknet lightclient...");
+        let starknet_lightclient_raw = StarkNetLightClientImpl::new(&config)?;
+
+        let beerus = BeerusLightClient::new_from_clients(
+            config.clone(),
+            Box::new(ethereum_lightclient_raw),
+            Box::new(starknet_lightclient_raw),
+        );
+        Ok(beerus)
+    }
+
+    /// Create a new Beerus Light Client service with the provided
+    /// custom Ethereum and Starknet clients
+    pub fn new_from_clients(
         config: Config,
-        //TODO: Check if we should just have &str as arguments
         ethereum_lightclient_raw: Box<dyn EthereumLightClient>,
         starknet_lightclient_raw: Box<dyn StarkNetLightClient>,
+        //TODO: Check if we should just have &str as arguments
     ) -> Self {
         // Create a new Ethereum light client.
         let ethereum_lightclient = Arc::new(Mutex::new(ethereum_lightclient_raw));

--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -561,7 +561,7 @@ mod tests {
     /// Test the `get_transaction_count` method when everything is fine.
     /// This test mocks external dependencies.
     /// It does not test the `get_transaction_count` method of the external dependencies.
-    /// It tests the `get_transaction_count` method of the Beerus light client.    
+    /// It tests the `get_transaction_count` method of the Beerus light client.
     #[tokio::test]
     async fn given_normal_conditions_when_query_tx_count_then_ok() {
         let (config, mut ethereum_lightclient_mock, starknet_lightclient_mock) = mock_clients();
@@ -1673,7 +1673,7 @@ mod tests {
             .return_once(|_request, _block_id| Ok(expected_result));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1715,7 +1715,7 @@ mod tests {
             .return_once(move |_block_nb, _address| Err(expected_error));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2219,7 +2219,7 @@ mod tests {
             .return_once(|_block_id| Ok(expected_result));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2262,7 +2262,7 @@ mod tests {
         };
 
         // Create a new Beerus light client.
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2307,7 +2307,7 @@ mod tests {
             .return_once(|| Ok(10));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2352,7 +2352,7 @@ mod tests {
             .return_once(|| Ok(10));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2384,7 +2384,7 @@ mod tests {
             .return_once(move |_block_id| Err(expected_error));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2428,7 +2428,7 @@ mod tests {
         };
 
         // Create a new Beerus light client.
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2449,7 +2449,7 @@ mod tests {
         let (config, ethereum_lightclient_mock, starknet_lightclient_mock) = mock_clients();
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2519,7 +2519,7 @@ mod tests {
         };
 
         // Create a new Beerus light client.
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2567,7 +2567,7 @@ mod tests {
         };
 
         // Create a new Beerus light client.
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2613,7 +2613,7 @@ mod tests {
             .return_once(|_tx_hash| Ok(expected_result));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),

--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -57,7 +57,7 @@ mod tests {
         let (config, ethereum_lightclient_mock, starknet_lightclient_mock) = mock_clients();
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -90,7 +90,7 @@ mod tests {
             .return_once(move || Ok(()));
 
         // When
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -125,7 +125,7 @@ mod tests {
             .return_once(move || Err(eyre!(expected_error)));
 
         // When
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -162,7 +162,7 @@ mod tests {
             .return_once(move |_| Ok(expected_value));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -203,7 +203,7 @@ mod tests {
             .return_once(move |_| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -242,7 +242,7 @@ mod tests {
             .return_once(move |_, _| Ok((123).into()));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -286,7 +286,7 @@ mod tests {
             .return_once(move |_, _| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -329,7 +329,7 @@ mod tests {
             .return_once(move |_, _| Ok(123));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -373,7 +373,7 @@ mod tests {
             .return_once(move |_, _| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -417,7 +417,7 @@ mod tests {
             .return_once(move || Ok(expected_block_number));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -454,7 +454,7 @@ mod tests {
             .return_once(move || Ok(expected_get_chain_id));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -486,7 +486,7 @@ mod tests {
         ethereum_lightclient_mock
             .expect_get_code()
             .return_once(move |_, _| Ok(expected_code));
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -531,7 +531,7 @@ mod tests {
             .return_once(move |_, _| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -571,7 +571,7 @@ mod tests {
         ethereum_lightclient_mock
             .expect_get_transaction_count()
             .return_once(move |_, _| Ok(expected_result));
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -616,7 +616,7 @@ mod tests {
             .return_once(move |_, _| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -653,7 +653,7 @@ mod tests {
         ethereum_lightclient_mock
             .expect_get_block_transaction_count_by_number()
             .return_once(move |_| Ok(expected_code));
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -697,7 +697,7 @@ mod tests {
             .return_once(move |_| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -761,7 +761,7 @@ mod tests {
             .return_once(move |_, _| Ok(_expected_block));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -801,7 +801,7 @@ mod tests {
             .return_once(move |_, _| Err(eyre!(_expected_error)));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -834,7 +834,7 @@ mod tests {
         ethereum_lightclient_mock
             .expect_get_block_transaction_count_by_hash()
             .return_once(move |_| Ok(expected_code));
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -878,7 +878,7 @@ mod tests {
             .return_once(move |_| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -921,7 +921,7 @@ mod tests {
             .expect_get_transaction_by_hash()
             .return_once(move |_| Ok(Some(_transaction)));
 
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -966,7 +966,7 @@ mod tests {
             .return_once(move |_| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1010,7 +1010,7 @@ mod tests {
             .expect_get_gas_price()
             .return_once(move || Ok(gas_price));
 
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1056,7 +1056,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1106,7 +1106,7 @@ mod tests {
             .expect_estimate_gas()
             .return_once(move |_| Ok(gas));
 
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1152,7 +1152,7 @@ mod tests {
             .return_once(move |_| Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1214,7 +1214,7 @@ mod tests {
             .return_once(move |_, _| Ok(_expected_block));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1256,7 +1256,7 @@ mod tests {
             .return_once(move |_, _| Err(eyre!(_expected_error)));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1297,7 +1297,7 @@ mod tests {
             .expect_get_priority_fee()
             .return_once(move || Ok(priority_fee));
 
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1339,7 +1339,7 @@ mod tests {
             .return_once(move || Err(eyre::eyre!("ethereum_lightclient_error")));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1388,7 +1388,7 @@ mod tests {
             .return_once(move || Err(eyre!(expected_error)));
 
         // When
-        let mut beerus = BeerusLightClient::new(
+        let mut beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1425,7 +1425,7 @@ mod tests {
             .return_once(move || Ok(expected_starknet_state_root));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1458,7 +1458,7 @@ mod tests {
             .return_once(move || Err(eyre!(expected_error)));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1499,7 +1499,7 @@ mod tests {
             .return_once(move || Ok(expected_starknet_block_number));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1533,7 +1533,7 @@ mod tests {
             .return_once(move || Err(eyre!(expected_error)));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1578,7 +1578,7 @@ mod tests {
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(10000)));
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1626,7 +1626,7 @@ mod tests {
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(10)));
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1754,7 +1754,7 @@ mod tests {
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(10)));
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1813,7 +1813,7 @@ mod tests {
             .return_once(move || Ok(U256::from(10)));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1848,7 +1848,7 @@ mod tests {
             .return_once(move || Ok(U256::from(10)));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1895,7 +1895,7 @@ mod tests {
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(10)));
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1937,7 +1937,7 @@ mod tests {
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(0)));
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -1976,7 +1976,7 @@ mod tests {
             .return_once(move || Ok(U256::from(10)));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2066,7 +2066,7 @@ mod tests {
             .return_once(move |_call_opts, _block_tag| Ok(expected_timestamp_bytes));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2102,7 +2102,7 @@ mod tests {
             });
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2140,7 +2140,7 @@ mod tests {
             .return_once(move |_call_opts, _block_tag| Ok(expected_timestamp_bytes));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2176,7 +2176,7 @@ mod tests {
             });
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2642,7 +2642,7 @@ mod tests {
             .return_once(move || Ok(expected_block_number));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2678,7 +2678,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2718,7 +2718,7 @@ mod tests {
             .return_once(move |_call_opts, _block_tag| Ok(expected_nonce_bytes));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2751,7 +2751,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2792,7 +2792,7 @@ mod tests {
             .return_once(move || Ok(expected_block_hash_and_number));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2835,7 +2835,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2873,7 +2873,7 @@ mod tests {
             .return_once(move |_block_id, _class_hash| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2919,7 +2919,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2962,7 +2962,7 @@ mod tests {
             .return_once(move |_call_opts, _block_tag| Ok(expected_fee_bytes));
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -2997,7 +2997,7 @@ mod tests {
             });
 
         // Create a new Beerus light client.
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config,
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3032,7 +3032,7 @@ mod tests {
             .return_once(move |_, _| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3074,7 +3074,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3114,7 +3114,7 @@ mod tests {
             .return_once(move |_block_id, _contract_address| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3160,7 +3160,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3201,7 +3201,7 @@ mod tests {
             .return_once(move |_block_id| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3242,7 +3242,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3281,7 +3281,7 @@ mod tests {
     //         .expect_get_logs()
     //         .return_once(move |_, _, _, _, _| Ok(vec![Log::default()]));
     //     // When
-    //     let beerus = BeerusLightClient::new(
+    //     let beerus = BeerusLightClient::new_from_clients(
     //         config.clone(),
     //         Box::new(ethereum_lightclient_mock),
     //         Box::new(starknet_lightclient_mock),
@@ -3326,7 +3326,7 @@ mod tests {
     //         .expect_get_logs()
     //         .return_once(move |_, _, _, _, _| Err(eyre::eyre!(expected_error.clone())));
     //     // When
-    //     let beerus = BeerusLightClient::new(
+    //     let beerus = BeerusLightClient::new_from_clients(
     //         config.clone(),
     //         Box::new(ethereum_lightclient_mock),
     //         Box::new(starknet_lightclient_mock),
@@ -3364,7 +3364,7 @@ mod tests {
             .return_once(move |_, _, _| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3414,7 +3414,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3464,7 +3464,7 @@ mod tests {
             .return_once(move || Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3503,7 +3503,7 @@ mod tests {
             .return_once(move || Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3543,7 +3543,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3585,7 +3585,7 @@ mod tests {
             .return_once(move |_, _| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3632,7 +3632,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3683,7 +3683,7 @@ mod tests {
             .expect_get_state_update()
             .return_once(move |_| Ok(expected));
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3735,7 +3735,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3776,7 +3776,7 @@ mod tests {
             .expect_add_invoke_transaction()
             .return_once(move |_| Ok(expected_result));
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3843,7 +3843,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3904,7 +3904,7 @@ mod tests {
             .expect_add_deploy_transaction()
             .return_once(move |_| Ok(expected_result));
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -3988,7 +3988,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4081,7 +4081,7 @@ mod tests {
             .return_once(move |_block_id| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4123,7 +4123,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4185,7 +4185,7 @@ mod tests {
             .return_once(move |_block_id, _index| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4228,7 +4228,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4271,7 +4271,7 @@ mod tests {
             .return_once(move || Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4311,7 +4311,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4359,7 +4359,7 @@ mod tests {
             .return_once(move |_| Ok(closure_return));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4398,7 +4398,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4458,7 +4458,7 @@ mod tests {
             .return_once(move |_block_id| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4503,7 +4503,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4567,7 +4567,7 @@ mod tests {
             .return_once(move |_| Ok(expected_result));
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4608,7 +4608,7 @@ mod tests {
             .expect_add_declare_transaction()
             .return_once(move |_| Ok(expected_result));
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4694,7 +4694,7 @@ mod tests {
             });
 
         // When
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
@@ -4771,7 +4771,7 @@ mod tests {
             .expect_pending_transactions()
             .return_once(move || Err(expected_error)); // Return a network error
 
-        let beerus = BeerusLightClient::new(
+        let beerus = BeerusLightClient::new_from_clients(
             config.clone(),
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),

--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -50,8 +50,34 @@ mod tests {
     const NETWORK_FAILURE: &str = "Network Failure";
     const TRANSACTION_HASH_NOT_FOUND: &str = "Transaction hash not found";
 
+    #[tokio::test]
+    async fn when_call_new_then_should_return_beerus_lightclient() {
+        use std::env;
+        // Given
+        // Mock config from env vars
+        env::set_var(
+            "ETHEREUM_CONSENSUS_RPC_URL",
+            "https://www.lightclientdata.org",
+        );
+        env::set_var(
+            "ETHEREUM_EXECUTION_RPC_URL",
+            "https://eth-mainnet.g.alchemy.com/v2/<YOUR_API_KEY>",
+        );
+        env::set_var(
+            "STARKNET_RPC_URL",
+            "https://starknet-mainnet.infura.io/v3/<YOUR_API_KEY>",
+        );
+        let config = Config::from_env();
+
+        // When
+        let beerus = BeerusLightClient::new(config.clone()).await.unwrap();
+
+        // Then
+        assert!(beerus.config.eq(&config));
+    }
+
     #[test]
-    fn when_call_new_then_should_return_beerus_lightclient() {
+    fn when_call_new_from_clients_then_should_return_beerus_lightclient() {
         // Given
         // Mock config, ethereum light client and starknet light client.
         let (config, ethereum_lightclient_mock, starknet_lightclient_mock) = mock_clients();

--- a/crates/beerus-core/tests/integration.rs
+++ b/crates/beerus-core/tests/integration.rs
@@ -32,8 +32,11 @@ mod test {
         helios_lightclient
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(1)));
-        let beerus =
-            BeerusLightClient::new(config, Box::new(helios_lightclient), starknet_lightclient);
+        let beerus = BeerusLightClient::new_from_clients(
+            config,
+            Box::new(helios_lightclient),
+            starknet_lightclient,
+        );
 
         let block_id = BlockId::Number(1);
         let storage_var = beerus
@@ -67,8 +70,11 @@ mod test {
                 }
                 .into())
             });
-        let beerus =
-            BeerusLightClient::new(config, Box::new(helios_lightclient), starknet_lightclient);
+        let beerus = BeerusLightClient::new_from_clients(
+            config,
+            Box::new(helios_lightclient),
+            starknet_lightclient,
+        );
 
         let block_id = BlockId::Number(1);
         let res = beerus
@@ -101,8 +107,11 @@ mod test {
         helios_lightclient
             .expect_starknet_last_proven_block()
             .return_once(move || Ok(U256::from(1)));
-        let beerus =
-            BeerusLightClient::new(config, Box::new(helios_lightclient), starknet_lightclient);
+        let beerus = BeerusLightClient::new_from_clients(
+            config,
+            Box::new(helios_lightclient),
+            starknet_lightclient,
+        );
         let storage_var = beerus
             .starknet_call_contract(
                 FieldElement::from_str("0x00").unwrap(),
@@ -135,8 +144,11 @@ mod test {
                 }
                 .into())
             });
-        let beerus =
-            BeerusLightClient::new(config, Box::new(helios_lightclient), starknet_lightclient);
+        let beerus = BeerusLightClient::new_from_clients(
+            config,
+            Box::new(helios_lightclient),
+            starknet_lightclient,
+        );
         let res = beerus
             .starknet_call_contract(
                 FieldElement::from_str("0x00").unwrap(),
@@ -161,8 +173,11 @@ mod test {
         let starknet_lightclient = Box::new(StarkNetLightClientImpl::new(&config).unwrap());
         let helios_lightclient = MockEthereumLightClient::new();
 
-        let beerus =
-            BeerusLightClient::new(config, Box::new(helios_lightclient), starknet_lightclient);
+        let beerus = BeerusLightClient::new_from_clients(
+            config,
+            Box::new(helios_lightclient),
+            starknet_lightclient,
+        );
 
         let (mock, expected_proof) = mock_get_contract_storage_proof(&server);
 

--- a/crates/beerus-js/src/lib.rs
+++ b/crates/beerus-js/src/lib.rs
@@ -7,7 +7,6 @@ use beerus_core::{
     config::Config,
     lightclient::{
         beerus::BeerusLightClient, beerus::SyncStatus,
-        ethereum::helios_lightclient::HeliosLightClient, starknet::StarkNetLightClientImpl,
     },
 };
 
@@ -36,11 +35,7 @@ impl BeerusClient {
 
         let cfg = Config::from_args(network, consensus_rpc, execution_rpc, starknet_rpc);
 
-        let eth_lc = HeliosLightClient::new(cfg.clone()).await.unwrap();
-
-        let starknet_lc = StarkNetLightClientImpl::new(&cfg).unwrap();
-
-        let mut beerus = BeerusLightClient::new(cfg, Box::new(eth_lc), Box::new(starknet_lc));
+        let mut beerus = BeerusLightClient::new(cfg);
 
         beerus.start().await.unwrap();
 

--- a/crates/beerus-rpc/src/main.rs
+++ b/crates/beerus-rpc/src/main.rs
@@ -1,10 +1,4 @@
-use beerus_core::{
-    config::Config,
-    lightclient::{
-        beerus::BeerusLightClient, ethereum::helios_lightclient::HeliosLightClient,
-        starknet::StarkNetLightClientImpl,
-    },
-};
+use beerus_core::{config::Config, lightclient::beerus::BeerusLightClient};
 use beerus_rpc::BeerusRpc;
 use env_logger::Env;
 use log::{error, info};
@@ -16,30 +10,14 @@ async fn main() {
 
     let config = Config::from_env();
 
-    info!("creating Ethereum(Helios) lightclient...");
-    let ethereum_lightclient = match HeliosLightClient::new(config.clone()).await {
-        Ok(ethereum_lightclient) => ethereum_lightclient,
-        Err(err) => {
-            error! {"{}", err};
-            exit(1);
-        }
-    };
-
-    info!("creating Starknet lightclient...");
-    let starknet_lightclient = match StarkNetLightClientImpl::new(&config) {
-        Ok(starknet_lightclient) => starknet_lightclient,
-        Err(err) => {
-            error! {"{}", err};
-            exit(1);
-        }
-    };
-
     info!("creating Beerus lightclient");
-    let mut beerus = BeerusLightClient::new(
-        config.clone(),
-        Box::new(ethereum_lightclient),
-        Box::new(starknet_lightclient),
-    );
+    let mut beerus = match BeerusLightClient::new(config.clone()).await {
+        Ok(beerus) => beerus,
+        Err(err) => {
+            error!("{}", err);
+            exit(1);
+        }
+    };
 
     info!("starting the Beerus light client...");
     if let Err(err) = beerus.start().await {

--- a/crates/beerus-rpc/src/main.rs
+++ b/crates/beerus-rpc/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
     let mut beerus = match BeerusLightClient::new(config.clone()).await {
         Ok(beerus) => beerus,
         Err(err) => {
-            error!("{}", err);
+            error! {"{}", err};
             exit(1);
         }
     };

--- a/crates/beerus-rpc/tests/common/mod.rs
+++ b/crates/beerus-rpc/tests/common/mod.rs
@@ -144,7 +144,7 @@ pub async fn setup_beerus_rpc() -> BeerusRpc {
     let ethereum_lightclient = MockEthereumLightClient::new();
     let starknet_lightclient = StarkNetLightClientImpl::new(&config).unwrap();
 
-    let beerus_client = BeerusLightClient::new(
+    let beerus_client = BeerusLightClient::new_from_clients(
         config,
         Box::new(ethereum_lightclient),
         Box::new(starknet_lightclient),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #516

# What is the new behavior?
`BeerusLightClient::new` creates client from config only

<!-- Please describe the behavior or changes that are being added by this PR. -->

Added function `BeerusLightClient::new_from_clients` which preserve old  `BeerusLightClient::new` behaviour for testing purpose

# Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
