### PR TITLE
dev: remove block_id_string_to_block_id_type

### DIFF
--- a/crates/beerus-core/tests/beerus.rs
+++ b/crates/beerus-core/tests/beerus.rs
@@ -13,7 +13,7 @@ mod tests {
             ethereum::helios_lightclient::HeliosLightClient,
             starknet::{StarkNetLightClient, StarkNetLightClientImpl},
         },
-        starknet_helper::{block_id_string_to_block_id_type, create_mock_broadcasted_transaction},
+        starknet_helper::create_mock_broadcasted_transaction,
     };
     use ethabi::Uint as U256;
     use ethers::types::{Address, Transaction, H256};
@@ -4139,7 +4139,7 @@ mod tests {
             Box::new(starknet_lightclient_mock),
         );
 
-        let block_id = block_id_string_to_block_id_type("tag", "latest").unwrap();
+        let block_id = BlockId::Tag(StarknetBlockTag::Latest);
         let (tx, _) = create_mock_broadcasted_transaction();
 
         let result = beerus
@@ -4185,7 +4185,7 @@ mod tests {
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
         );
-        let block_id = block_id_string_to_block_id_type("tag", "latest").unwrap();
+        let block_id = BlockId::Tag(StarknetBlockTag::Latest);
         let (tx, _) = create_mock_broadcasted_transaction();
 
         let result = beerus
@@ -4237,7 +4237,7 @@ mod tests {
             Box::new(starknet_lightclient_mock),
         );
         // Query the transaction data given a hash on Ethereum.
-        let block_id = block_id_string_to_block_id_type("tag", "latest").unwrap();
+        let block_id = BlockId::Tag(StarknetBlockTag::Latest);
         let result = beerus
             .starknet_lightclient
             .get_state_update(&block_id)
@@ -4288,7 +4288,7 @@ mod tests {
             Box::new(ethereum_lightclient_mock),
             Box::new(starknet_lightclient_mock),
         );
-        let block_id = block_id_string_to_block_id_type("tag", "latest").unwrap();
+        let block_id = BlockId::Tag(StarknetBlockTag::Latest);
         let result = beerus
             .starknet_lightclient
             .get_state_update(&block_id)

--- a/crates/beerus-rpc/tests/common/mod.rs
+++ b/crates/beerus-rpc/tests/common/mod.rs
@@ -4,7 +4,7 @@ use beerus_core::{
         beerus::BeerusLightClient, ethereum::MockEthereumLightClient,
         starknet::StarkNetLightClientImpl,
     },
-    starknet_helper::{block_id_string_to_block_id_type, create_mock_broadcasted_transaction},
+    starknet_helper::create_mock_broadcasted_transaction,
 };
 use beerus_rpc::BeerusRpc;
 use reqwest::{Method, StatusCode};
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use starknet::core::types::FieldElement;
 use starknet::providers::jsonrpc::models::{BlockId, BlockTag, EventFilter, FunctionCall};
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 use wiremock::{
     matchers::{body_json, method},
     Mock, MockServer, ResponseTemplate,
@@ -174,11 +174,13 @@ fn mock_get_block_transaction_count() -> Mock {
 }
 
 fn mock_estimate_fee() -> Mock {
-    let block_type = "hash".to_string();
-    let block_hash =
-        "0x0147c4b0f702079384e26d9d34a15e7758881e32b219fc68c076b09d0be13f8c".to_string();
     let broadcasted_transaction = create_mock_broadcasted_transaction();
-    let block_id = block_id_string_to_block_id_type(&block_type, &block_hash).unwrap();
+    let block_id = BlockId::Hash(
+        FieldElement::from_str(
+            "0x0147c4b0f702079384e26d9d34a15e7758881e32b219fc68c076b09d0be13f8c",
+        )
+        .unwrap(),
+    );
 
     Mock::given(method("POST"))
         .and(body_json(StarknetRpcBaseData::starknet_estimate_fee((


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #540 

# What is the new behavior?
The function `crates/beerus-rpc/src/starknet_helper.rs/block_id_string_to_block_id_type` is removed and tests are refactored to use starknet-rs block id type directly
<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information
N/A
<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
